### PR TITLE
fix: restore chat availability after /abort

### DIFF
--- a/src/feishu/control-router.ts
+++ b/src/feishu/control-router.ts
@@ -172,6 +172,10 @@ export interface OpenCodeSessionClient {
   }): Promise<{ data?: unknown; error?: unknown }>;
   status(parameters?: Record<string, unknown>): Promise<{ data?: unknown }>;
   abort(parameters?: Record<string, unknown>): Promise<{ data?: unknown }>;
+  children?(parameters: {
+    sessionID: string;
+    directory?: string;
+  }): Promise<{ data?: unknown; error?: unknown }>;
   messages(parameters: {
     sessionID: string;
     directory?: string;
@@ -2007,6 +2011,8 @@ export class ControlRouter {
   private async handleAbort(receiveId: string): Promise<ControlCommandResult> {
     const currentSession = this.sessionManager.getChatSession(receiveId);
     if (!currentSession) {
+      this.settings.clearChatStatusMessageId(receiveId);
+      this.interactionManager.clearBusy(receiveId);
       await this.renderer.sendText(receiveId, "没有活跃的会话可以取消");
       return { success: false, message: "No active session to abort" };
     }
@@ -2017,31 +2023,23 @@ export class ControlRouter {
     }
 
     try {
-      const abortResponse = await this.openCodeSession.abort({
-        sessionID: currentSession.id,
-        directory: currentSession.directory,
-      });
-      if (
-        isRecord(abortResponse) &&
-        "error" in abortResponse &&
-        abortResponse.error
-      ) {
-        throw abortResponse.error;
-      }
+      await this.abortSessionTree(currentSession.id, currentSession.directory);
 
       const finalState = await this.pollAbortSessionState(
         currentSession.id,
         currentSession.directory,
       );
       if (finalState === "busy") {
-        if (turnState) {
-          turnState.abortRequested = false;
-        }
+        const completedTurnState = this.clearAbortedTurnState(
+          receiveId,
+          currentSession.id,
+        );
         const message =
-          "⚠️ 已发送取消请求，但任务仍在处理中，请稍后再试 /abort 或用 /status 确认状态";
+          "⚠️ 已发送取消请求，本地会话已恢复空闲；后台任务仍在结束，请稍后重试，或用 /status 确认远端状态";
         this.logger.warn(
           `[ControlRouter] Abort request did not settle in time: session=${currentSession.id}, directory=${currentSession.directory}`,
         );
+        await this.updateAbortedStatusCard(completedTurnState, message);
         await this.renderer.sendText(receiveId, message);
         return {
           success: false,
@@ -2049,13 +2047,10 @@ export class ControlRouter {
         };
       }
 
-      const completedTurnState = this.statusStore?.clear(currentSession.id);
-      if (completedTurnState) {
-        this.disposeTurnResources(completedTurnState);
-      }
-
-      this.settings.clearChatStatusMessageId(receiveId);
-      this.interactionManager.clearBusy(receiveId);
+      const completedTurnState = this.clearAbortedTurnState(
+        receiveId,
+        currentSession.id,
+      );
 
       await this.updateAbortedStatusCard(completedTurnState);
 
@@ -2066,12 +2061,135 @@ export class ControlRouter {
         message: `Session aborted: ${currentSession.id}`,
       };
     } catch (error) {
-      if (turnState) {
-        turnState.abortRequested = false;
-      }
+      const completedTurnState = this.clearAbortedTurnState(
+        receiveId,
+        currentSession.id,
+      );
       this.logger.error("[ControlRouter] Failed to abort session", error);
-      await this.renderer.sendText(receiveId, "❌ 取消操作失败，请重试");
+      const message =
+        "⚠️ 取消请求失败，但本地会话已恢复空闲；请稍后用 /status 检查远端状态";
+      await this.updateAbortedStatusCard(completedTurnState, message);
+      await this.renderer.sendText(receiveId, message);
       return { success: false, message: "Failed to abort session" };
+    }
+  }
+
+  private clearAbortedTurnState(
+    receiveId: string,
+    sessionId: string,
+  ): StatusTurnState | undefined {
+    const completedTurnState = this.statusStore?.clear(sessionId);
+    if (completedTurnState) {
+      this.disposeTurnResources(completedTurnState);
+    }
+
+    this.settings.clearChatStatusMessageId(receiveId);
+    this.interactionManager.clearBusy(receiveId);
+
+    return completedTurnState;
+  }
+
+  private async abortSessionTree(
+    sessionId: string,
+    directory: string,
+  ): Promise<void> {
+    const descendantIds = await this.collectDescendantSessionIds(
+      sessionId,
+      directory,
+    );
+
+    for (const descendantId of descendantIds.reverse()) {
+      await this.sendAbortRequest(descendantId, directory, false);
+    }
+
+    await this.sendAbortRequest(sessionId, directory, true);
+
+    if (descendantIds.length > 0) {
+      this.logger.info(
+        `[ControlRouter] Abort requested for session tree: root=${sessionId}, descendants=${descendantIds.length}`,
+      );
+    }
+  }
+
+  private async collectDescendantSessionIds(
+    sessionId: string,
+    directory: string,
+  ): Promise<string[]> {
+    if (!this.openCodeSession.children) {
+      return [];
+    }
+
+    const pending = [sessionId];
+    const visited = new Set<string>([sessionId]);
+    const descendants: string[] = [];
+
+    while (pending.length > 0) {
+      const parentSessionId = pending.shift();
+      if (!parentSessionId) {
+        continue;
+      }
+
+      try {
+        const response = await this.openCodeSession.children({
+          sessionID: parentSessionId,
+          directory,
+        });
+        if (isRecord(response) && "error" in response && response.error) {
+          throw response.error;
+        }
+
+        const childSessions = Array.isArray(response.data) ? response.data : [];
+        for (const childSession of childSessions) {
+          if (!isRecord(childSession)) {
+            continue;
+          }
+
+          const childSessionId = getTrimmedString(childSession.id);
+          if (!childSessionId || visited.has(childSessionId)) {
+            continue;
+          }
+
+          visited.add(childSessionId);
+          descendants.push(childSessionId);
+          pending.push(childSessionId);
+        }
+      } catch (error) {
+        this.logger.warn(
+          `[ControlRouter] Failed to list child sessions during abort: parentSession=${parentSessionId}, directory=${directory}`,
+          error,
+        );
+      }
+    }
+
+    return descendants;
+  }
+
+  private async sendAbortRequest(
+    sessionId: string,
+    directory: string,
+    failOnError: boolean,
+  ): Promise<void> {
+    try {
+      const abortResponse = await this.openCodeSession.abort({
+        sessionID: sessionId,
+        directory,
+      });
+      if (
+        isRecord(abortResponse) &&
+        "error" in abortResponse &&
+        abortResponse.error
+      ) {
+        throw abortResponse.error;
+      }
+    } catch (error) {
+      if (failOnError) {
+        throw error;
+      }
+
+      this.logger.warn(
+        `[ControlRouter] Failed to abort child session: session=${sessionId}, directory=${directory}`,
+        error,
+      );
     }
   }
 
@@ -2131,6 +2249,7 @@ export class ControlRouter {
 
   private async updateAbortedStatusCard(
     turnState: StatusTurnState | undefined,
+    message: string = "✅ 已取消当前操作",
   ): Promise<void> {
     if (!turnState?.statusCardMessageId) {
       return;
@@ -2140,7 +2259,7 @@ export class ControlRouter {
       await this.renderer.updateCompleteCard(
         turnState.statusCardMessageId,
         getAbortCardTitle(),
-        "✅ 已取消当前操作",
+        message,
         {
           elapsedMs: Math.max(0, Date.now() - turnState.turnStartTime),
           tokens: turnState.latestTokens,

--- a/tests/unit/control-commands.test.ts
+++ b/tests/unit/control-commands.test.ts
@@ -104,6 +104,7 @@ function createMockOpenCodeClient() {
         .fn()
         .mockResolvedValue({ data: { "sess-1": { type: "idle" } } }),
       abort: vi.fn().mockResolvedValue({ data: true }),
+      children: vi.fn().mockResolvedValue({ data: [] }),
       messages: vi.fn().mockResolvedValue({ data: [] }),
       prompt: vi.fn().mockResolvedValue(undefined),
     },
@@ -1013,6 +1014,67 @@ describe("ControlRouter — command dispatch", () => {
     );
   });
 
+  it("/abort aborts discovered child sessions before the active session", async () => {
+    const openCodeClient = createMockOpenCodeClient();
+    openCodeClient.session.children
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "child-1",
+            title: "Child",
+            directory: "/workspace",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "grandchild-1",
+            title: "Grandchild",
+            directory: "/workspace",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+    const sessionManager = createMockSessionManager();
+    sessionManager.getChatSession.mockReturnValue({
+      id: "sess-1",
+      title: "Test",
+      directory: "/workspace",
+    });
+    const router = createRouter({ openCodeClient, sessionManager });
+
+    const resultPromise = router.handleCommand("chat-1", "/abort");
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(openCodeClient.session.children).toHaveBeenNthCalledWith(1, {
+      sessionID: "sess-1",
+      directory: "/workspace",
+    });
+    expect(openCodeClient.session.children).toHaveBeenNthCalledWith(2, {
+      sessionID: "child-1",
+      directory: "/workspace",
+    });
+    expect(openCodeClient.session.children).toHaveBeenNthCalledWith(3, {
+      sessionID: "grandchild-1",
+      directory: "/workspace",
+    });
+    expect(openCodeClient.session.abort).toHaveBeenNthCalledWith(1, {
+      sessionID: "grandchild-1",
+      directory: "/workspace",
+    });
+    expect(openCodeClient.session.abort).toHaveBeenNthCalledWith(2, {
+      sessionID: "child-1",
+      directory: "/workspace",
+    });
+    expect(openCodeClient.session.abort).toHaveBeenNthCalledWith(3, {
+      sessionID: "sess-1",
+      directory: "/workspace",
+    });
+  });
+
   it("/abort patches the active status card to an aborted state", async () => {
     const openCodeClient = createMockOpenCodeClient();
     const settings = createMockSettings();
@@ -1098,7 +1160,7 @@ describe("ControlRouter — command dispatch", () => {
     expect(interactionManager.clearBusy).toHaveBeenCalledWith("chat-1");
   });
 
-  it("/abort warns when the server stays busy and preserves local busy cleanup", async () => {
+  it("/abort warns when the server stays busy but still restores local busy state", async () => {
     const openCodeClient = createMockOpenCodeClient();
     openCodeClient.session.status.mockResolvedValue({
       data: { "sess-1": { type: "busy" } },
@@ -1125,24 +1187,81 @@ describe("ControlRouter — command dispatch", () => {
     const result = await resultPromise;
 
     expect(result.success).toBe(false);
-    expect(interactionManager.clearBusy).not.toHaveBeenCalled();
-    expect(settings.clearChatStatusMessageId).not.toHaveBeenCalled();
+    expect(interactionManager.clearBusy).toHaveBeenCalledWith("chat-1");
+    expect(settings.clearChatStatusMessageId).toHaveBeenCalledWith("chat-1");
     expect(renderer.sendText).toHaveBeenCalledWith(
       "chat-1",
-      "⚠️ 已发送取消请求，但任务仍在处理中，请稍后再试 /abort 或用 /status 确认状态",
+      "⚠️ 已发送取消请求，本地会话已恢复空闲；后台任务仍在结束，请稍后重试，或用 /status 确认远端状态",
+    );
+  });
+
+  it("/abort clears local busy state when the abort request fails", async () => {
+    const openCodeClient = createMockOpenCodeClient();
+    openCodeClient.session.abort.mockRejectedValue(new Error("network down"));
+    const settings = createMockSettings();
+    const sessionManager = createMockSessionManager();
+    sessionManager.getChatSession.mockReturnValue({
+      id: "sess-1",
+      title: "Test",
+      directory: "/workspace",
+    });
+    const interactionManager = createMockInteractionManager();
+    const renderer = createMockRenderer();
+    const statusStore = new StatusStore();
+    const abortController = new AbortController();
+
+    statusStore.startTurn({
+      sessionId: "sess-1",
+      directory: "/workspace",
+      receiveId: "chat-1",
+      sourceMessageId: "source-1",
+    });
+    statusStore.update("sess-1", (state) => {
+      state.statusCardMessageId = "status-card-1";
+      state.subscriptionAbortController = abortController;
+    });
+
+    const router = createRouter({
+      openCodeClient,
+      settingsManager: settings,
+      sessionManager,
+      renderer,
+      interactionManager,
+      statusStore,
+    });
+
+    const result = await router.handleCommand("chat-1", "/abort");
+
+    expect(result.success).toBe(false);
+    expect(statusStore.get("sess-1")).toBeUndefined();
+    expect(abortController.signal.aborted).toBe(true);
+    expect(interactionManager.clearBusy).toHaveBeenCalledWith("chat-1");
+    expect(settings.clearChatStatusMessageId).toHaveBeenCalledWith("chat-1");
+    expect(renderer.sendText).toHaveBeenCalledWith(
+      "chat-1",
+      "⚠️ 取消请求失败，但本地会话已恢复空闲；请稍后用 /status 检查远端状态",
     );
   });
 
   it("/abort returns failure when no active session", async () => {
     const renderer = createMockRenderer();
+    const settings = createMockSettings();
     const sessionManager = createMockSessionManager();
+    const interactionManager = createMockInteractionManager();
     sessionManager.getChatSession.mockReturnValue(undefined);
-    const router = createRouter({ renderer, sessionManager });
+    const router = createRouter({
+      renderer,
+      settingsManager: settings,
+      sessionManager,
+      interactionManager,
+    });
 
     const result = await router.handleCommand("chat-1", "/abort");
 
     expect(result.success).toBe(false);
     expect(result.message).toContain("No active session");
+    expect(settings.clearChatStatusMessageId).toHaveBeenCalledWith("chat-1");
+    expect(interactionManager.clearBusy).toHaveBeenCalledWith("chat-1");
     expect(renderer.sendText).toHaveBeenCalledWith(
       "chat-1",
       "没有活跃的会话可以取消",

--- a/tests/unit/control-selection-cards.test.ts
+++ b/tests/unit/control-selection-cards.test.ts
@@ -63,6 +63,7 @@ function createMockRenderer() {
     sendPost: vi.fn().mockResolvedValue(undefined),
     replyPost: vi.fn().mockResolvedValue(undefined),
     updateCard: vi.fn().mockResolvedValue(undefined),
+    updateCompleteCard: vi.fn().mockResolvedValue(undefined),
     renderStatusCard: vi.fn().mockResolvedValue(undefined),
     updateStatusCard: vi.fn().mockResolvedValue(undefined),
     renderQuestionCard: vi.fn().mockResolvedValue(undefined),
@@ -616,8 +617,9 @@ describe("Selection card builders", () => {
 
     expect(result).toEqual({
       toast: {
-        type: "success",
-        content: "New session selected: New Session (new-session-1)",
+        type: "error",
+        content:
+          "Unable to determine which chat should receive the new session. Please try again from the original chat.",
       },
     });
     expect(renderer.sendText).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- clear local Feishu busy/status state even when `/abort` cannot fully settle, so chats recover instead of staying wedged behind lingering subagents
- best-effort abort child OpenCode sessions discovered via `session.children()` before aborting the active session
- add regression coverage for timeout/error recovery and descendant aborts, and align the stale no-chat-id callback test expectation so the suite stays green

## Verification
- npm run lint
- npm run test
- npm run build

Fixes #28