### PR TITLE
fix: tighten Feishu group mention filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Required:
 
 Common optional settings:
 
-- `FEISHU_BOT_OPEN_ID` — enables exact `@bot` matching in group chats
+- `FEISHU_BOT_OPEN_ID` — required for group-chat prompts and uploads; enables exact `@bot` matching
 - `FEISHU_CONNECTION_TYPE` — `ws` or `webhook` (default `ws`)
 - `FEISHU_CARD_CALLBACK_URL` — optional callback endpoint for Feishu card actions
 - `FEISHU_CARD_CALLBACK_VERIFICATION_TOKEN` — defaults to empty when callback is disabled; required when `FEISHU_CONNECTION_TYPE=webhook` or callback URL is configured
@@ -89,7 +89,7 @@ The bridge currently supports these slash commands in Feishu chat:
 - If no model/agent has been set yet, `/status` shows `Model: {ASSISTANT_NAME} default` / `Agent: {ASSISTANT_NAME} default` (configurable via `ASSISTANT_NAME` env var).
 - When `OPENCODE_WORKDIR` is set, `/projects` scans immediate subdirectories of that path from the bridge process. Selecting a new directory triggers auto-discovery on the OpenCode server, so the same path must also be meaningful there if the bridge and OpenCode server run on different hosts.
 - During busy periods, control commands such as `/status`, `/help`, and `/abort` are still allowed.
-- In group chats, normal prompt messages require `@bot` mention behavior configured by Feishu permissions and bridge settings.
+- In group chats, normal prompt messages and file/image uploads require an explicit `@bot` mention and a configured `FEISHU_BOT_OPEN_ID`.
 
 ## Response UX highlights
 

--- a/src/app/runtime-event-handlers.ts
+++ b/src/app/runtime-event-handlers.ts
@@ -1,26 +1,29 @@
 import { readFile } from "node:fs/promises";
 import { extname } from "node:path";
 import { pathToFileURL } from "node:url";
+import type {
+  CardActionResponse,
+  ControlRouter,
+} from "../feishu/control-router.js";
+import {
+  normalizeFeishuEvent,
+  parseFeishuMessageAddressing,
+  parseFeishuPromptEvent,
+} from "../feishu/message-events.js";
 import type { FeishuMessageReceiveEvent } from "../feishu/event-router.js";
-import { parseFeishuPromptEvent } from "../feishu/message-events.js";
+import type { FileHandler } from "../feishu/file-handler.js";
+import type { StoredFile } from "../feishu/file-store.js";
+import type { PermissionCardHandler } from "../feishu/handlers/permission.js";
 import type {
   PromptIngressHandler,
   PromptIngressResult,
 } from "../feishu/handlers/prompt.js";
 import type { PromptPartInput } from "../feishu/handlers/prompt.js";
-import type { FileHandler } from "../feishu/file-handler.js";
-import type { StoredFile } from "../feishu/file-store.js";
-import type { ResponsePipelineController } from "../feishu/response-pipeline.js";
 import type { QuestionCardHandler } from "../feishu/handlers/question.js";
-import type { PermissionCardHandler } from "../feishu/handlers/permission.js";
 import type { FeishuRenderer } from "../feishu/renderer.js";
-import type {
-  CardActionResponse,
-  ControlRouter,
-} from "../feishu/control-router.js";
+import type { ResponsePipelineController } from "../feishu/response-pipeline.js";
 import type { Logger } from "../utils/logger.js";
 import { logger as defaultLogger } from "../utils/logger.js";
-import { normalizeFeishuEvent } from "../feishu/message-events.js";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -268,6 +271,22 @@ export function createRuntimeEventHandlers(
       if (!chatId || !messageId) {
         logger.warn(
           `[RuntimeEventHandlers] Dropping inbound media event with missing identifiers: eventId=${eventId ?? "unknown"}, messageId=${messageId ?? "unknown"}, chatId=${chatId ?? "unknown"}, messageType=${messageType ?? "unknown"}`,
+        );
+        return;
+      }
+
+      const addressing = parseFeishuMessageAddressing(event, {
+        botOpenId: options.botOpenId ?? null,
+      });
+      if (!addressing) {
+        logger.warn(
+          `[RuntimeEventHandlers] Dropping inbound media event with invalid addressing metadata: eventId=${eventId ?? "unknown"}, messageId=${messageId}, chatId=${chatId}, messageType=${messageType ?? "unknown"}`,
+        );
+        return;
+      }
+      if (!addressing.isDirectMessage && !addressing.botMentioned) {
+        logger.debug(
+          `[RuntimeEventHandlers] Ignoring inbound media event in group chat without explicit bot mention: eventId=${eventId ?? "unknown"}, messageId=${messageId}, chatId=${chatId}, messageType=${messageType ?? "unknown"}`,
         );
         return;
       }

--- a/src/feishu/message-events.ts
+++ b/src/feishu/message-events.ts
@@ -69,6 +69,13 @@ export interface ParsedFeishuPromptEvent {
   botMentioned: boolean;
 }
 
+export interface ParsedFeishuMessageAddressing {
+  chatType: string;
+  mentions: FeishuMention[];
+  isDirectMessage: boolean;
+  botMentioned: boolean;
+}
+
 export interface ParseFeishuPromptEventOptions {
   botOpenId?: string | null;
 }
@@ -83,6 +90,30 @@ interface RawFeishuMessage {
   message_type?: string;
   content?: string;
   mentions?: unknown;
+}
+
+function resolveFeishuMessageAddressing(
+  rawMessage: Pick<RawFeishuMessage, "chat_type" | "mentions">,
+  options: ParseFeishuPromptEventOptions = {},
+): ParsedFeishuMessageAddressing | null {
+  const chatType = getString(rawMessage.chat_type);
+  if (!chatType) {
+    return null;
+  }
+
+  const mentions = extractMentions(rawMessage.mentions);
+  const mentionedOpenIds = new Set(extractMentionedOpenIds(mentions));
+  const isDirectMessage = chatType === "p2p";
+  const botMentioned = options.botOpenId
+    ? mentionedOpenIds.has(options.botOpenId)
+    : false;
+
+  return {
+    chatType,
+    mentions,
+    isDirectMessage,
+    botMentioned,
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -137,6 +168,20 @@ export function extractMentionedOpenIds(
       (openId): openId is string =>
         typeof openId === "string" && openId.length > 0,
     );
+}
+
+export function parseFeishuMessageAddressing(
+  event: FeishuMessageReceiveEvent,
+  options: ParseFeishuPromptEventOptions = {},
+): ParsedFeishuMessageAddressing | null {
+  const normalized = normalizeFeishuEvent(event);
+  const rawMessage = normalized.message;
+
+  if (!rawMessage) {
+    return null;
+  }
+
+  return resolveFeishuMessageAddressing(rawMessage, options);
 }
 
 function extractTextFromPostSegment(segment: unknown): string | null {
@@ -262,10 +307,10 @@ export function parseFeishuPromptEvent(
 
   const messageId = getString(rawMessage.message_id);
   const chatId = getString(rawMessage.chat_id);
-  const chatType = getString(rawMessage.chat_type);
   const rawContent = getString(rawMessage.content);
+  const addressing = resolveFeishuMessageAddressing(rawMessage, options);
 
-  if (!messageId || !chatId || !chatType || !rawContent) {
+  if (!messageId || !chatId || !rawContent || !addressing) {
     return null;
   }
 
@@ -274,14 +319,7 @@ export function parseFeishuPromptEvent(
     return null;
   }
 
-  const mentions = extractMentions(rawMessage.mentions);
-  const mentionedOpenIds = new Set(extractMentionedOpenIds(mentions));
-  const isDirectMessage = chatType === "p2p";
-  const botMentioned = options.botOpenId
-    ? mentionedOpenIds.has(options.botOpenId)
-    : mentions.length > 0;
-
-  if (!isDirectMessage && !botMentioned) {
+  if (!addressing.isDirectMessage && !addressing.botMentioned) {
     return null;
   }
 
@@ -292,7 +330,7 @@ export function parseFeishuPromptEvent(
     eventId: header?.event_id ?? null,
     messageId,
     chatId,
-    chatType,
+    chatType: addressing.chatType,
     messageType,
     text,
     rawContent,
@@ -300,8 +338,8 @@ export function parseFeishuPromptEvent(
     threadId: getString(rawMessage.thread_id),
     rootId: getString(rawMessage.root_id),
     parentId: getString(rawMessage.parent_id),
-    mentions,
-    isDirectMessage,
-    botMentioned,
+    mentions: addressing.mentions,
+    isDirectMessage: addressing.isDirectMessage,
+    botMentioned: addressing.botMentioned,
   };
 }

--- a/tests/unit/feishu-message-events.test.ts
+++ b/tests/unit/feishu-message-events.test.ts
@@ -132,6 +132,31 @@ describe("feishu message event helpers", () => {
     expect(parseFeishuPromptEvent(event, { botOpenId: "ou_other" })).toBeNull();
   });
 
+  it("rejects group text when FEISHU_BOT_OPEN_ID is unset", () => {
+    const event = createEvent({
+      event: {
+        sender: { sender_id: { open_id: "ou_sender" } },
+        message: {
+          message_id: "om_group_missing_bot_id",
+          chat_id: "oc_group",
+          chat_type: "group",
+          message_type: "text",
+          content: JSON.stringify({ text: "@_user_1 summarize this" }),
+          mentions: [
+            {
+              key: "@_user_1",
+              id: { open_id: "ou_bot" },
+              name: "OpenCode Bot",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(parseFeishuPromptEvent(event)).toBeNull();
+    expect(parseFeishuPromptEvent(event, { botOpenId: null })).toBeNull();
+  });
+
   it("rejects unsupported or invalid payloads safely", () => {
     expect(
       parseFeishuPromptEvent(

--- a/tests/unit/runtime-event-handlers-queue.test.ts
+++ b/tests/unit/runtime-event-handlers-queue.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { createRuntimeEventHandlers } from "../../src/app/runtime-event-handlers.js";
@@ -57,6 +60,41 @@ function createFileEvent(options: {
           file_key: "file-key-1",
           file_name: options.fileName ?? "review.txt",
           file_size: 12,
+        }),
+        mentions: options.mentions ?? [],
+      },
+      sender: {
+        sender_id: { open_id: "user-open-id" },
+      },
+    },
+  };
+}
+
+function createImageEvent(options: {
+  eventId: string;
+  messageId: string;
+  chatId: string;
+  chatType?: "p2p" | "group";
+  mentions?: Array<{
+    key: string;
+    id: { open_id?: string; union_id?: string; user_id?: string };
+    name?: string;
+    tenant_key?: string;
+  }>;
+}): FeishuMessageReceiveEvent {
+  return {
+    header: {
+      event_id: options.eventId,
+      event_type: "im.message.receive_v1",
+    },
+    event: {
+      message: {
+        message_id: options.messageId,
+        chat_id: options.chatId,
+        chat_type: options.chatType ?? "group",
+        message_type: "image",
+        content: JSON.stringify({
+          image_key: "image-key-1",
         }),
         mentions: options.mentions ?? [],
       },
@@ -498,5 +536,211 @@ describe("runtime event handlers chat serialization", () => {
       ],
     });
     expect(promptIngressHandler.handleMessageEvent).not.toHaveBeenCalled();
+  });
+
+  it("ignores group image messages without an explicit bot mention", async () => {
+    const promptIngressHandler = {
+      handlePromptInput: vi.fn(),
+      handleMessageEvent: vi.fn(),
+    };
+    const fileHandler = {
+      isInboundFileMessage: vi.fn().mockReturnValue(true),
+      handleInboundFile: vi.fn(),
+      downloadFile: vi.fn(),
+      cleanup: vi.fn(),
+    };
+
+    const handlers = createRuntimeEventHandlers({
+      promptIngressHandler: promptIngressHandler as never,
+      pipelineController: {
+        startTurn: vi.fn(),
+        recordFollowUpAppended: vi.fn().mockResolvedValue(undefined),
+      },
+      questionCardHandler: {
+        handleCardAction: vi.fn(),
+        canHandleTextReply: vi.fn().mockReturnValue(false),
+        handleTextReply: vi.fn(),
+      },
+      permissionCardHandler: {
+        handleCardAction: vi.fn(),
+      },
+      controlRouter: {
+        parseCommand: vi.fn().mockReturnValue(null),
+        handleCommand: vi.fn(),
+        handleCardAction: vi.fn(),
+      },
+      fileHandler: fileHandler as never,
+      botOpenId: "bot-open-id",
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await handlers.handleMessageReceived(
+      createImageEvent({
+        eventId: "evt-image-no-mention",
+        messageId: "msg-image-no-mention",
+        chatId: "chat-group-1",
+      }),
+    );
+
+    expect(fileHandler.handleInboundFile).not.toHaveBeenCalled();
+    expect(promptIngressHandler.handlePromptInput).not.toHaveBeenCalled();
+    expect(promptIngressHandler.handleMessageEvent).not.toHaveBeenCalled();
+  });
+
+  it("ignores group image messages when FEISHU_BOT_OPEN_ID is unset", async () => {
+    const promptIngressHandler = {
+      handlePromptInput: vi.fn(),
+      handleMessageEvent: vi.fn(),
+    };
+    const fileHandler = {
+      isInboundFileMessage: vi.fn().mockReturnValue(true),
+      handleInboundFile: vi.fn(),
+      downloadFile: vi.fn(),
+      cleanup: vi.fn(),
+    };
+
+    const handlers = createRuntimeEventHandlers({
+      promptIngressHandler: promptIngressHandler as never,
+      pipelineController: {
+        startTurn: vi.fn(),
+        recordFollowUpAppended: vi.fn().mockResolvedValue(undefined),
+      },
+      questionCardHandler: {
+        handleCardAction: vi.fn(),
+        canHandleTextReply: vi.fn().mockReturnValue(false),
+        handleTextReply: vi.fn(),
+      },
+      permissionCardHandler: {
+        handleCardAction: vi.fn(),
+      },
+      controlRouter: {
+        parseCommand: vi.fn().mockReturnValue(null),
+        handleCommand: vi.fn(),
+        handleCardAction: vi.fn(),
+      },
+      fileHandler: fileHandler as never,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await handlers.handleMessageReceived(
+      createImageEvent({
+        eventId: "evt-image-no-bot-id",
+        messageId: "msg-image-no-bot-id",
+        chatId: "chat-group-1",
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: "some-other-user" },
+            name: "Another User",
+          },
+        ],
+      }),
+    );
+
+    expect(fileHandler.handleInboundFile).not.toHaveBeenCalled();
+    expect(promptIngressHandler.handlePromptInput).not.toHaveBeenCalled();
+    expect(promptIngressHandler.handleMessageEvent).not.toHaveBeenCalled();
+  });
+
+  it("dispatches group image messages when the bot is explicitly mentioned", async () => {
+    const imageTempDir = mkdtempSync(join(tmpdir(), "runtime-image-test-"));
+    const imagePath = join(imageTempDir, "image.png");
+    writeFileSync(imagePath, Buffer.from([137, 80, 78, 71, 13, 10, 26, 10, 0]));
+
+    try {
+      const promptIngressHandler = {
+        handlePromptInput: vi
+          .fn()
+          .mockResolvedValue({ kind: "blocked", reason: "noop" } as const),
+        handleMessageEvent: vi.fn(),
+      };
+      const fileHandler = {
+        isInboundFileMessage: vi.fn().mockReturnValue(true),
+        handleInboundFile: vi.fn().mockResolvedValue({
+          fileName: "image.png",
+          fileSize: 9,
+          localPath: imagePath,
+          mimeType: "image/png",
+        }),
+        downloadFile: vi.fn(),
+        cleanup: vi.fn(),
+      };
+
+      const handlers = createRuntimeEventHandlers({
+        promptIngressHandler: promptIngressHandler as never,
+        pipelineController: {
+          startTurn: vi.fn(),
+          recordFollowUpAppended: vi.fn().mockResolvedValue(undefined),
+        },
+        questionCardHandler: {
+          handleCardAction: vi.fn(),
+          canHandleTextReply: vi.fn().mockReturnValue(false),
+          handleTextReply: vi.fn(),
+        },
+        permissionCardHandler: {
+          handleCardAction: vi.fn(),
+        },
+        controlRouter: {
+          parseCommand: vi.fn().mockReturnValue(null),
+          handleCommand: vi.fn(),
+          handleCardAction: vi.fn(),
+        },
+        fileHandler: fileHandler as never,
+        botOpenId: "bot-open-id",
+        logger: {
+          debug: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+      });
+
+      await handlers.handleMessageReceived(
+        createImageEvent({
+          eventId: "evt-image-with-mention",
+          messageId: "msg-image-with-mention",
+          chatId: "chat-group-1",
+          mentions: [
+            {
+              key: "@_user_1",
+              id: { open_id: "bot-open-id" },
+              name: "OpenCode Bot",
+            },
+          ],
+        }),
+      );
+
+      expect(fileHandler.handleInboundFile).toHaveBeenCalledTimes(1);
+      expect(promptIngressHandler.handlePromptInput).toHaveBeenCalledWith({
+        messageId: "msg-image-with-mention",
+        chatId: "chat-group-1",
+        text: "Please review the attached file image.png.",
+        parts: [
+          {
+            type: "text",
+            text: "Please review the attached file image.png.",
+          },
+          {
+            type: "file",
+            mime: "image/png",
+            filename: "image.png",
+            url: expect.stringMatching(/^data:image\/png;base64,/),
+          },
+        ],
+      });
+      expect(promptIngressHandler.handleMessageEvent).not.toHaveBeenCalled();
+    } finally {
+      rmSync(imageTempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/runtime-event-handlers-queue.test.ts
+++ b/tests/unit/runtime-event-handlers-queue.test.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { createRuntimeEventHandlers } from "../../src/app/runtime-event-handlers.js";
 import type { FeishuMessageReceiveEvent } from "../../src/feishu/event-router.js";
@@ -20,6 +21,44 @@ function createTextEvent(options: {
         chat_type: "p2p",
         message_type: "text",
         content: JSON.stringify({ text: options.text }),
+      },
+      sender: {
+        sender_id: { open_id: "user-open-id" },
+      },
+    },
+  };
+}
+
+function createFileEvent(options: {
+  eventId: string;
+  messageId: string;
+  chatId: string;
+  chatType?: "p2p" | "group";
+  fileName?: string;
+  mentions?: Array<{
+    key: string;
+    id: { open_id?: string; union_id?: string; user_id?: string };
+    name?: string;
+    tenant_key?: string;
+  }>;
+}): FeishuMessageReceiveEvent {
+  return {
+    header: {
+      event_id: options.eventId,
+      event_type: "im.message.receive_v1",
+    },
+    event: {
+      message: {
+        message_id: options.messageId,
+        chat_id: options.chatId,
+        chat_type: options.chatType ?? "group",
+        message_type: "file",
+        content: JSON.stringify({
+          file_key: "file-key-1",
+          file_name: options.fileName ?? "review.txt",
+          file_size: 12,
+        }),
+        mentions: options.mentions ?? [],
       },
       sender: {
         sender_id: { open_id: "user-open-id" },
@@ -261,5 +300,203 @@ describe("runtime event handlers chat serialization", () => {
       "chat-1",
       "📝 已将新消息追加到当前任务，继续处理中…",
     );
+  });
+
+  it("ignores group file messages without an explicit bot mention", async () => {
+    const promptIngressHandler = {
+      handlePromptInput: vi.fn(),
+      handleMessageEvent: vi.fn(),
+    };
+    const fileHandler = {
+      isInboundFileMessage: vi.fn().mockReturnValue(true),
+      handleInboundFile: vi.fn(),
+      downloadFile: vi.fn(),
+      cleanup: vi.fn(),
+    };
+
+    const handlers = createRuntimeEventHandlers({
+      promptIngressHandler: promptIngressHandler as never,
+      pipelineController: {
+        startTurn: vi.fn(),
+        recordFollowUpAppended: vi.fn().mockResolvedValue(undefined),
+      },
+      questionCardHandler: {
+        handleCardAction: vi.fn(),
+        canHandleTextReply: vi.fn().mockReturnValue(false),
+        handleTextReply: vi.fn(),
+      },
+      permissionCardHandler: {
+        handleCardAction: vi.fn(),
+      },
+      controlRouter: {
+        parseCommand: vi.fn().mockReturnValue(null),
+        handleCommand: vi.fn(),
+        handleCardAction: vi.fn(),
+      },
+      fileHandler: fileHandler as never,
+      botOpenId: "bot-open-id",
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await handlers.handleMessageReceived(
+      createFileEvent({
+        eventId: "evt-file-no-mention",
+        messageId: "msg-file-no-mention",
+        chatId: "chat-group-1",
+      }),
+    );
+
+    expect(fileHandler.handleInboundFile).not.toHaveBeenCalled();
+    expect(promptIngressHandler.handlePromptInput).not.toHaveBeenCalled();
+    expect(promptIngressHandler.handleMessageEvent).not.toHaveBeenCalled();
+  });
+
+  it("ignores group file messages when FEISHU_BOT_OPEN_ID is unset", async () => {
+    const promptIngressHandler = {
+      handlePromptInput: vi.fn(),
+      handleMessageEvent: vi.fn(),
+    };
+    const fileHandler = {
+      isInboundFileMessage: vi.fn().mockReturnValue(true),
+      handleInboundFile: vi.fn(),
+      downloadFile: vi.fn(),
+      cleanup: vi.fn(),
+    };
+
+    const handlers = createRuntimeEventHandlers({
+      promptIngressHandler: promptIngressHandler as never,
+      pipelineController: {
+        startTurn: vi.fn(),
+        recordFollowUpAppended: vi.fn().mockResolvedValue(undefined),
+      },
+      questionCardHandler: {
+        handleCardAction: vi.fn(),
+        canHandleTextReply: vi.fn().mockReturnValue(false),
+        handleTextReply: vi.fn(),
+      },
+      permissionCardHandler: {
+        handleCardAction: vi.fn(),
+      },
+      controlRouter: {
+        parseCommand: vi.fn().mockReturnValue(null),
+        handleCommand: vi.fn(),
+        handleCardAction: vi.fn(),
+      },
+      fileHandler: fileHandler as never,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await handlers.handleMessageReceived(
+      createFileEvent({
+        eventId: "evt-file-no-bot-id",
+        messageId: "msg-file-no-bot-id",
+        chatId: "chat-group-1",
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: "some-other-user" },
+            name: "Another User",
+          },
+        ],
+      }),
+    );
+
+    expect(fileHandler.handleInboundFile).not.toHaveBeenCalled();
+    expect(promptIngressHandler.handlePromptInput).not.toHaveBeenCalled();
+    expect(promptIngressHandler.handleMessageEvent).not.toHaveBeenCalled();
+  });
+
+  it("dispatches group file messages when the bot is explicitly mentioned", async () => {
+    const promptIngressHandler = {
+      handlePromptInput: vi
+        .fn()
+        .mockResolvedValue({ kind: "blocked", reason: "noop" } as const),
+      handleMessageEvent: vi.fn(),
+    };
+    const fileHandler = {
+      isInboundFileMessage: vi.fn().mockReturnValue(true),
+      handleInboundFile: vi.fn().mockResolvedValue({
+        fileName: "review.txt",
+        fileSize: 12,
+        localPath: "/tmp/review.txt",
+        mimeType: "text/plain",
+      }),
+      downloadFile: vi.fn(),
+      cleanup: vi.fn(),
+    };
+
+    const handlers = createRuntimeEventHandlers({
+      promptIngressHandler: promptIngressHandler as never,
+      pipelineController: {
+        startTurn: vi.fn(),
+        recordFollowUpAppended: vi.fn().mockResolvedValue(undefined),
+      },
+      questionCardHandler: {
+        handleCardAction: vi.fn(),
+        canHandleTextReply: vi.fn().mockReturnValue(false),
+        handleTextReply: vi.fn(),
+      },
+      permissionCardHandler: {
+        handleCardAction: vi.fn(),
+      },
+      controlRouter: {
+        parseCommand: vi.fn().mockReturnValue(null),
+        handleCommand: vi.fn(),
+        handleCardAction: vi.fn(),
+      },
+      fileHandler: fileHandler as never,
+      botOpenId: "bot-open-id",
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await handlers.handleMessageReceived(
+      createFileEvent({
+        eventId: "evt-file-with-mention",
+        messageId: "msg-file-with-mention",
+        chatId: "chat-group-1",
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: "bot-open-id" },
+            name: "OpenCode Bot",
+          },
+        ],
+      }),
+    );
+
+    expect(fileHandler.handleInboundFile).toHaveBeenCalledTimes(1);
+    expect(promptIngressHandler.handlePromptInput).toHaveBeenCalledWith({
+      messageId: "msg-file-with-mention",
+      chatId: "chat-group-1",
+      text: "Please review the attached file review.txt.",
+      parts: [
+        {
+          type: "text",
+          text: "Please review the attached file review.txt.",
+        },
+        {
+          type: "file",
+          mime: "text/plain",
+          filename: "review.txt",
+          url: pathToFileURL("/tmp/review.txt").href,
+        },
+      ],
+    });
+    expect(promptIngressHandler.handleMessageEvent).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- reuse a shared Feishu addressing helper so group chat handling only proceeds when the configured bot open ID is explicitly mentioned
- stop file and image uploads from bypassing the group mention gate, and add regression coverage for both parser and runtime media handling
- clarify in the README that group-chat prompts and uploads require `FEISHU_BOT_OPEN_ID`

## Testing
- npm test -- tests/unit/feishu-message-events.test.ts
- npm test -- tests/unit/runtime-event-handlers-queue.test.ts
- npm run test
- npm run lint
- npm run build

Closes #31