### PR TITLE
refactor(orchestration): align pending-interaction model with OpenCode browser app

### DIFF
--- a/src/app/runtime-summary-aggregator.ts
+++ b/src/app/runtime-summary-aggregator.ts
@@ -1,4 +1,14 @@
 import type { Event } from "@opencode-ai/sdk/v2";
+import type { FileHandler } from "../feishu/file-handler.js";
+import type { FileStore } from "../feishu/file-store.js";
+import type { PermissionCardHandler } from "../feishu/handlers/permission.js";
+import type { QuestionCardHandler } from "../feishu/handlers/question.js";
+import { QUESTION_GUIDED_REPLY_PREFIX } from "../feishu/handlers/question.js";
+import type { StatusStore } from "../feishu/status-store.js";
+import type { InteractionManager } from "../interaction/manager.js";
+import type { PendingInteractionStore } from "../pending/store.js";
+import type { PermissionManager } from "../permission/manager.js";
+import type { QuestionManager } from "../question/manager.js";
 import { SummaryAggregator } from "../summary/aggregator.js";
 import type {
   SummaryCallbacks,
@@ -6,15 +16,6 @@ import type {
   SummaryQuestionEvent,
   SummaryToolEvent,
 } from "../summary/types.js";
-import type { StatusStore } from "../feishu/status-store.js";
-import type { QuestionManager } from "../question/manager.js";
-import type { PermissionManager } from "../permission/manager.js";
-import type { InteractionManager } from "../interaction/manager.js";
-import type { QuestionCardHandler } from "../feishu/handlers/question.js";
-import { QUESTION_GUIDED_REPLY_PREFIX } from "../feishu/handlers/question.js";
-import type { PermissionCardHandler } from "../feishu/handlers/permission.js";
-import type { FileHandler } from "../feishu/file-handler.js";
-import type { FileStore } from "../feishu/file-store.js";
 import type { Logger } from "../utils/logger.js";
 import { logger as defaultLogger } from "../utils/logger.js";
 
@@ -23,6 +24,7 @@ export interface RuntimeSummaryAggregatorOptions {
   questionManager: QuestionManager;
   permissionManager: PermissionManager;
   interactionManager: InteractionManager;
+  pendingStore?: PendingInteractionStore;
   questionCardHandler: Pick<QuestionCardHandler, "handleQuestionEvent">;
   permissionCardHandler: Pick<PermissionCardHandler, "handlePermissionEvent">;
   fileHandler: Pick<FileHandler, "egressFile">;
@@ -46,7 +48,6 @@ function runAsync(
 
 export class RuntimeSummaryAggregator {
   private readonly aggregator: SummaryAggregator;
-  private callbacks: SummaryCallbacks = {};
   private readonly logger: Logger;
 
   constructor(private readonly options: RuntimeSummaryAggregatorOptions) {
@@ -57,7 +58,6 @@ export class RuntimeSummaryAggregator {
   }
 
   setCallbacks(callbacks: SummaryCallbacks): void {
-    this.callbacks = callbacks;
     this.aggregator.setCallbacks({
       ...callbacks,
       onQuestion: (event) => {
@@ -93,9 +93,20 @@ export class RuntimeSummaryAggregator {
           );
         }
       },
+      onQuestionReplied: (sessionId, requestId) => {
+        callbacks.onQuestionReplied?.(sessionId, requestId);
+        this.handleQuestionReplied(sessionId, requestId);
+      },
+      onQuestionRejected: (sessionId, requestId) => {
+        callbacks.onQuestionRejected?.(sessionId, requestId);
+        this.handleQuestionRejected(sessionId, requestId);
+      },
+      onPermissionReplied: (sessionId, requestId) => {
+        callbacks.onPermissionReplied?.(sessionId, requestId);
+        this.handlePermissionReplied(sessionId, requestId);
+      },
       onCleared: () => {
         callbacks.onCleared?.();
-        this.options.interactionManager.clearAll("aggregator_cleared");
       },
     });
   }
@@ -123,6 +134,14 @@ export class RuntimeSummaryAggregator {
     if (!turn) {
       return;
     }
+
+    this.options.pendingStore?.add(
+      event.requestId,
+      event.sessionId,
+      turn.directory,
+      turn.receiveId,
+      "question",
+    );
 
     const expectedInput =
       firstQuestion.options.length > 0 && firstQuestion.custom
@@ -160,6 +179,14 @@ export class RuntimeSummaryAggregator {
       return;
     }
 
+    this.options.pendingStore?.add(
+      event.request.id,
+      event.sessionId,
+      turn.directory,
+      turn.receiveId,
+      "permission",
+    );
+
     this.options.interactionManager.start(turn.receiveId, {
       kind: "permission",
       expectedInput: "callback",
@@ -181,6 +208,51 @@ export class RuntimeSummaryAggregator {
       "Failed to render permission interaction",
       this.options.trackTask,
     );
+  }
+
+  private handleQuestionReplied(sessionId: string, requestId: string): void {
+    this.logger.info(
+      `[RuntimeSummaryAggregator] Question replied: session=${sessionId}, requestId=${requestId}`,
+    );
+    this.options.pendingStore?.remove(requestId);
+    this.options.questionManager.clear();
+
+    const turn = this.options.statusStore.get(sessionId);
+    if (turn) {
+      this.options.interactionManager.clear(turn.receiveId, "question_replied");
+    }
+  }
+
+  private handleQuestionRejected(sessionId: string, requestId: string): void {
+    this.logger.info(
+      `[RuntimeSummaryAggregator] Question rejected: session=${sessionId}, requestId=${requestId}`,
+    );
+    this.options.pendingStore?.remove(requestId);
+    this.options.questionManager.clear();
+
+    const turn = this.options.statusStore.get(sessionId);
+    if (turn) {
+      this.options.interactionManager.clear(
+        turn.receiveId,
+        "question_rejected",
+      );
+    }
+  }
+
+  private handlePermissionReplied(sessionId: string, requestId: string): void {
+    this.logger.info(
+      `[RuntimeSummaryAggregator] Permission replied: session=${sessionId}, requestId=${requestId}`,
+    );
+    this.options.pendingStore?.remove(requestId);
+    this.options.permissionManager.removeByRequestId(requestId);
+
+    const turn = this.options.statusStore.get(sessionId);
+    if (turn) {
+      this.options.interactionManager.clear(
+        turn.receiveId,
+        "permission_replied",
+      );
+    }
   }
 
   private handleTool(event: SummaryToolEvent): void {

--- a/src/app/runtime-summary-aggregator.ts
+++ b/src/app/runtime-summary-aggregator.ts
@@ -119,6 +119,18 @@ export class RuntimeSummaryAggregator {
     this.aggregator.processEvent(event);
   }
 
+  private getReceiveIdForRequest(
+    sessionId: string,
+    requestId: string,
+  ): string | null {
+    const pending = this.options.pendingStore?.get(requestId);
+    if (pending?.chatId) {
+      return pending.chatId;
+    }
+
+    return this.options.statusStore.get(sessionId)?.receiveId ?? null;
+  }
+
   private handleQuestion(event: SummaryQuestionEvent): void {
     this.options.questionManager.startQuestions(
       event.questions,
@@ -214,12 +226,22 @@ export class RuntimeSummaryAggregator {
     this.logger.info(
       `[RuntimeSummaryAggregator] Question replied: session=${sessionId}, requestId=${requestId}`,
     );
-    this.options.pendingStore?.remove(requestId);
-    this.options.questionManager.clear();
 
-    const turn = this.options.statusStore.get(sessionId);
-    if (turn) {
-      this.options.interactionManager.clear(turn.receiveId, "question_replied");
+    const receiveId = this.getReceiveIdForRequest(sessionId, requestId);
+    const activeRequestId = this.options.questionManager.getRequestID();
+
+    this.options.pendingStore?.remove(requestId);
+
+    if (activeRequestId === requestId) {
+      this.options.questionManager.clear();
+    } else {
+      this.logger.warn(
+        `[RuntimeSummaryAggregator] Ignoring stale question reply for requestId=${requestId}; activeRequestId=${activeRequestId ?? "none"}`,
+      );
+    }
+
+    if (receiveId) {
+      this.options.interactionManager.clear(receiveId, "question_replied");
     }
   }
 
@@ -227,15 +249,22 @@ export class RuntimeSummaryAggregator {
     this.logger.info(
       `[RuntimeSummaryAggregator] Question rejected: session=${sessionId}, requestId=${requestId}`,
     );
-    this.options.pendingStore?.remove(requestId);
-    this.options.questionManager.clear();
 
-    const turn = this.options.statusStore.get(sessionId);
-    if (turn) {
-      this.options.interactionManager.clear(
-        turn.receiveId,
-        "question_rejected",
+    const receiveId = this.getReceiveIdForRequest(sessionId, requestId);
+    const activeRequestId = this.options.questionManager.getRequestID();
+
+    this.options.pendingStore?.remove(requestId);
+
+    if (activeRequestId === requestId) {
+      this.options.questionManager.clear();
+    } else {
+      this.logger.warn(
+        `[RuntimeSummaryAggregator] Ignoring stale question rejection for requestId=${requestId}; activeRequestId=${activeRequestId ?? "none"}`,
       );
+    }
+
+    if (receiveId) {
+      this.options.interactionManager.clear(receiveId, "question_rejected");
     }
   }
 
@@ -243,15 +272,14 @@ export class RuntimeSummaryAggregator {
     this.logger.info(
       `[RuntimeSummaryAggregator] Permission replied: session=${sessionId}, requestId=${requestId}`,
     );
+
+    const receiveId = this.getReceiveIdForRequest(sessionId, requestId);
+
     this.options.pendingStore?.remove(requestId);
     this.options.permissionManager.removeByRequestId(requestId);
 
-    const turn = this.options.statusStore.get(sessionId);
-    if (turn) {
-      this.options.interactionManager.clear(
-        turn.receiveId,
-        "permission_replied",
-      );
+    if (receiveId) {
+      this.options.interactionManager.clear(receiveId, "permission_replied");
     }
   }
 

--- a/src/app/start-feishu-app.ts
+++ b/src/app/start-feishu-app.ts
@@ -7,6 +7,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { type AppConfig, ConfigValidationError, getConfig } from "../config.js";
+import { EventSupervisor } from "../events/supervisor.js";
 import { createCardCallbackRequestHandler } from "../feishu/card-callback-server.js";
 import { ControlRouter } from "../feishu/control-router.js";
 import { createEventDeduplicator } from "../feishu/event-deduplicator.js";
@@ -33,14 +34,16 @@ import { ResponsePipelineController } from "../feishu/response-pipeline.js";
 import { createFeishuClients } from "../feishu/sdk.js";
 import { statusStore } from "../feishu/status-store.js";
 import { startFeishuWsClient } from "../feishu/ws-client.js";
-import { interactionManager } from "../interaction/manager.js";
+import { InteractionManager } from "../interaction/manager.js";
 import { createOpenCodeClient } from "../opencode/client.js";
+import { openCodeEventSubscriber } from "../opencode/events.js";
 import { createSessionMessageFetcher } from "../opencode/message-fetcher.js";
 import { createOpenCodePromptClient } from "../opencode/prompt-client.js";
-import { permissionManager } from "../permission/manager.js";
-import { questionManager } from "../question/manager.js";
-import { sessionManager } from "../session/manager.js";
-import { settingsManager } from "../settings/manager.js";
+import { PendingInteractionStore } from "../pending/store.js";
+import { PermissionManager } from "../permission/manager.js";
+import { QuestionManager } from "../question/manager.js";
+import { SessionManager } from "../session/manager.js";
+import { SettingsManager } from "../settings/manager.js";
 import { logger } from "../utils/logger.js";
 import { APP_VERSION } from "../version.js";
 import { createRuntimeEventHandlers } from "./runtime-event-handlers.js";
@@ -111,20 +114,25 @@ export async function startFeishuApp(): Promise<void> {
   const openCodePromptAsyncClient: OpenCodePromptAsyncClient =
     createOpenCodePromptClient(openCodeClient, logger);
 
-  // Step 5: Create managers (singletons)
+  // Step 5: Create managers
   const managers = {
-    settings: settingsManager,
+    settings: new SettingsManager(),
+    question: new QuestionManager(),
+    permission: new PermissionManager(),
+    interaction: new InteractionManager(),
+  };
+  const sessionManager = new SessionManager(managers.settings);
+  const managersWithSession = {
+    ...managers,
     session: sessionManager,
-    question: questionManager,
-    permission: permissionManager,
-    interaction: interactionManager,
   };
 
-  await managers.settings.loadSettings();
-  if (!managers.settings.getCurrentProject()) {
+  await managersWithSession.settings.loadSettings();
+  if (!managersWithSession.settings.getCurrentProject()) {
     const defaultWorktree =
-      managers.settings.getCurrentSession()?.directory ?? process.cwd();
-    managers.settings.setCurrentProject({
+      managersWithSession.settings.getCurrentSession()?.directory ??
+      process.cwd();
+    managersWithSession.settings.setCurrentProject({
       id: defaultWorktree,
       worktree: defaultWorktree,
       name: "Default workspace",
@@ -136,17 +144,17 @@ export async function startFeishuApp(): Promise<void> {
 
   // Step 6: Create handlers
   const questionCardHandler = new QuestionCardHandler({
-    questionManager: managers.question,
+    questionManager: managersWithSession.question,
     renderer,
     openCodeClient: openCodeQuestionClient,
-    interactionManager: managers.interaction,
+    interactionManager: managersWithSession.interaction,
   });
 
   const permissionCardHandler = new PermissionCardHandler({
-    permissionManager: managers.permission,
+    permissionManager: managersWithSession.permission,
     renderer,
     openCodeClient: openCodePermissionClient,
-    interactionManager: managers.interaction,
+    interactionManager: managersWithSession.interaction,
   });
 
   const fileStore = new FileStore({ logger });
@@ -163,15 +171,15 @@ export async function startFeishuApp(): Promise<void> {
   });
 
   const controlRouter = new ControlRouter({
-    settingsManager: managers.settings,
-    sessionManager: managers.session,
+    settingsManager: managersWithSession.settings,
+    sessionManager: managersWithSession.session,
     renderer,
     openCodeClient,
     feishuClient: feishuClients.client,
     catalogCacheTtlMs: config.controlCatalog.cacheTtlMs,
     catalogModelStatePath: config.controlCatalog.modelStatePath,
     messageReader,
-    interactionManager: managers.interaction,
+    interactionManager: managersWithSession.interaction,
     statusStore,
     cardActionsEnabled:
       config.connectionType === "ws" ||
@@ -181,8 +189,8 @@ export async function startFeishuApp(): Promise<void> {
   });
 
   const promptIngressHandler = new PromptIngressHandler({
-    settings: managers.settings,
-    interactionManager: managers.interaction,
+    settings: managersWithSession.settings,
+    interactionManager: managersWithSession.interaction,
     openCodeSession: openCodeClient.session,
     openCodeSessionStatus: openCodeClient.session,
     openCodeSessionMessages: openCodeClient.session,
@@ -192,12 +200,14 @@ export async function startFeishuApp(): Promise<void> {
   });
 
   const inboundFilesBySession = new Map<string, StoredFile[]>();
+  const pendingStore = new PendingInteractionStore();
 
   const summaryAggregator = new RuntimeSummaryAggregator({
     statusStore,
-    questionManager: managers.question,
-    permissionManager: managers.permission,
-    interactionManager: managers.interaction,
+    questionManager: managersWithSession.question,
+    permissionManager: managersWithSession.permission,
+    interactionManager: managersWithSession.interaction,
+    pendingStore,
     questionCardHandler,
     permissionCardHandler,
     fileHandler,
@@ -212,15 +222,24 @@ export async function startFeishuApp(): Promise<void> {
     },
   });
 
+  const eventSupervisor = new EventSupervisor({
+    eventSubscriber: openCodeEventSubscriber,
+    summaryAggregator,
+    pendingStore,
+    client: openCodeClient,
+    logger,
+  });
+
   // Step 7: Create ResponsePipelineController
   const sessionMessageFetcher = createSessionMessageFetcher(openCodeClient);
   const pipelineController = new ResponsePipelineController({
+    eventSupervisor,
     summaryAggregator,
     sessionMessageFetcher,
     renderer,
     imageResolver,
-    settingsManager: managers.settings,
-    interactionManager: managers.interaction,
+    settingsManager: managersWithSession.settings,
+    interactionManager: managersWithSession.interaction,
     statusStore,
     config,
   });
@@ -350,6 +369,7 @@ export async function startFeishuApp(): Promise<void> {
       logger.info(`Aborting active session: ${sessionId}`);
     }
     statusStore.clearAll();
+    eventSupervisor.stop();
 
     httpServer?.close(() => {
       logger.info("HTTP server closed");

--- a/src/app/start-feishu-app.ts
+++ b/src/app/start-feishu-app.ts
@@ -170,6 +170,10 @@ export async function startFeishuApp(): Promise<void> {
     logger,
   });
 
+  let handleFatalSubscriptionError:
+    | ((directory: string, error: unknown) => void)
+    | null = null;
+
   const controlRouter = new ControlRouter({
     settingsManager: managersWithSession.settings,
     sessionManager: managersWithSession.session,
@@ -228,6 +232,9 @@ export async function startFeishuApp(): Promise<void> {
     pendingStore,
     client: openCodeClient,
     logger,
+    onFatalSubscriptionError: (directory, error) => {
+      handleFatalSubscriptionError?.(directory, error);
+    },
   });
 
   // Step 7: Create ResponsePipelineController
@@ -243,6 +250,9 @@ export async function startFeishuApp(): Promise<void> {
     statusStore,
     config,
   });
+  handleFatalSubscriptionError = (directory, error) => {
+    pipelineController.handleEventSupervisorFailure(directory, error);
+  };
   pipelineControllerInstance = pipelineController;
 
   // Step 8: Create event router with message and card action handlers

--- a/src/events/supervisor.ts
+++ b/src/events/supervisor.ts
@@ -26,12 +26,15 @@ export interface EventSupervisorOptions {
   pendingStore: PendingInteractionStore;
   client?: EventSupervisorClient;
   logger: Logger;
+  resubscribeDelayMs?: number;
 }
 
 export interface EventSupervisorSnapshot {
   directory: string | null;
   isSubscribed: boolean;
 }
+
+const DEFAULT_RESUBSCRIBE_DELAY_MS = 1_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -52,6 +55,8 @@ function getRequestId(event: Event): string | undefined {
 export class EventSupervisor {
   private currentDirectory: string | null = null;
   private isSubscribed = false;
+  private subscriptionGeneration = 0;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private readonly options: EventSupervisorOptions) {}
 
@@ -70,33 +75,25 @@ export class EventSupervisor {
       this.stop();
     }
 
+    this.clearRetryTimer();
+    this.subscriptionGeneration += 1;
     this.currentDirectory = directory;
     this.isSubscribed = true;
 
-    void this.options.eventSubscriber
-      .subscribeToEvents(directory, (event) => {
-        this.onEvent(event);
-      })
-      .catch((error: unknown) => {
+    this.startSubscription(directory, this.subscriptionGeneration);
+    void this.bootstrap(directory, this.subscriptionGeneration).catch(
+      (error: unknown) => {
         this.options.logger.error(
-          `[EventSupervisor] Event subscription failed for ${directory}`,
+          `[EventSupervisor] Bootstrap failed for ${directory}`,
           error,
         );
-        if (this.currentDirectory === directory) {
-          this.currentDirectory = null;
-          this.isSubscribed = false;
-        }
-      });
-
-    void this.bootstrap(directory).catch((error: unknown) => {
-      this.options.logger.error(
-        `[EventSupervisor] Bootstrap failed for ${directory}`,
-        error,
-      );
-    });
+      },
+    );
   }
 
   stop(): void {
+    this.clearRetryTimer();
+    this.subscriptionGeneration += 1;
     this.options.eventSubscriber.stopEventListening();
     this.currentDirectory = null;
     this.isSubscribed = false;
@@ -107,6 +104,63 @@ export class EventSupervisor {
       directory: this.currentDirectory,
       isSubscribed: this.isSubscribed,
     };
+  }
+
+  private startSubscription(directory: string, generation: number): void {
+    void this.options.eventSubscriber
+      .subscribeToEvents(directory, (event) => {
+        this.onEvent(event);
+      })
+      .catch((error: unknown) => {
+        this.options.logger.error(
+          `[EventSupervisor] Event subscription failed for ${directory}`,
+          error,
+        );
+
+        if (!this.isCurrentSubscription(directory, generation)) {
+          return;
+        }
+
+        this.scheduleRetry(directory, generation);
+      });
+  }
+
+  private isCurrentSubscription(
+    directory: string,
+    generation: number,
+  ): boolean {
+    return (
+      this.isSubscribed &&
+      this.currentDirectory === directory &&
+      this.subscriptionGeneration === generation
+    );
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
+  private scheduleRetry(directory: string, generation: number): void {
+    this.clearRetryTimer();
+
+    const delay =
+      this.options.resubscribeDelayMs ?? DEFAULT_RESUBSCRIBE_DELAY_MS;
+    this.options.logger.warn(
+      `[EventSupervisor] Retrying subscription for ${directory} in ${delay}ms`,
+    );
+
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+
+      if (!this.isCurrentSubscription(directory, generation)) {
+        return;
+      }
+
+      this.startSubscription(directory, generation);
+    }, delay);
   }
 
   private onEvent(event: Event): void {
@@ -129,7 +183,10 @@ export class EventSupervisor {
     this.options.pendingStore.remove(requestId);
   }
 
-  private async bootstrap(directory: string): Promise<void> {
+  private async bootstrap(
+    directory: string,
+    generation: number,
+  ): Promise<void> {
     if (!this.options.client) {
       return;
     }
@@ -138,8 +195,14 @@ export class EventSupervisor {
       const questionResponse = await this.options.client.question.list({
         directory,
       });
+      if (!this.isCurrentSubscription(directory, generation)) {
+        return;
+      }
       const questions = questionResponse.data ?? [];
       for (const item of questions) {
+        if (!this.isCurrentSubscription(directory, generation)) {
+          return;
+        }
         this.options.pendingStore.add(
           item.id,
           item.sessionID,
@@ -162,8 +225,14 @@ export class EventSupervisor {
       const permissionResponse = await this.options.client.permission.list({
         directory,
       });
+      if (!this.isCurrentSubscription(directory, generation)) {
+        return;
+      }
       const permissions = permissionResponse.data ?? [];
       for (const item of permissions) {
+        if (!this.isCurrentSubscription(directory, generation)) {
+          return;
+        }
         this.options.pendingStore.add(
           item.id,
           item.sessionID,

--- a/src/events/supervisor.ts
+++ b/src/events/supervisor.ts
@@ -1,0 +1,185 @@
+import type { Event } from "@opencode-ai/sdk/v2";
+import type { OpenCodeEventSubscriber } from "../opencode/events.js";
+import type { PendingInteractionStore } from "../pending/store.js";
+import type { Logger } from "../utils/logger.js";
+
+interface EventSupervisorAggregator {
+  processEvent(event: Event): void;
+}
+
+interface EventSupervisorClient {
+  question: {
+    list(params?: {
+      directory?: string;
+    }): Promise<{ data?: Array<{ id: string; sessionID: string }> }>;
+  };
+  permission: {
+    list(params?: {
+      directory?: string;
+    }): Promise<{ data?: Array<{ id: string; sessionID: string }> }>;
+  };
+}
+
+export interface EventSupervisorOptions {
+  eventSubscriber: OpenCodeEventSubscriber;
+  summaryAggregator: EventSupervisorAggregator;
+  pendingStore: PendingInteractionStore;
+  client?: EventSupervisorClient;
+  logger: Logger;
+}
+
+export interface EventSupervisorSnapshot {
+  directory: string | null;
+  isSubscribed: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function getRequestId(event: Event): string | undefined {
+  const rawEvent = event as { properties?: unknown };
+  const properties = isRecord(rawEvent.properties)
+    ? rawEvent.properties
+    : undefined;
+  return getString(properties?.requestID) ?? getString(properties?.id);
+}
+
+export class EventSupervisor {
+  private currentDirectory: string | null = null;
+  private isSubscribed = false;
+
+  constructor(private readonly options: EventSupervisorOptions) {}
+
+  ensureSubscribed(directory: string): void {
+    if (this.currentDirectory === directory && this.isSubscribed) {
+      this.options.logger.debug(
+        `[EventSupervisor] Subscription already active for ${directory}`,
+      );
+      return;
+    }
+
+    if (this.currentDirectory && this.currentDirectory !== directory) {
+      this.options.logger.info(
+        `[EventSupervisor] Switching subscription from ${this.currentDirectory} to ${directory}`,
+      );
+      this.stop();
+    }
+
+    this.currentDirectory = directory;
+    this.isSubscribed = true;
+
+    void this.options.eventSubscriber
+      .subscribeToEvents(directory, (event) => {
+        this.onEvent(event);
+      })
+      .catch((error: unknown) => {
+        this.options.logger.error(
+          `[EventSupervisor] Event subscription failed for ${directory}`,
+          error,
+        );
+        if (this.currentDirectory === directory) {
+          this.currentDirectory = null;
+          this.isSubscribed = false;
+        }
+      });
+
+    void this.bootstrap(directory).catch((error: unknown) => {
+      this.options.logger.error(
+        `[EventSupervisor] Bootstrap failed for ${directory}`,
+        error,
+      );
+    });
+  }
+
+  stop(): void {
+    this.options.eventSubscriber.stopEventListening();
+    this.currentDirectory = null;
+    this.isSubscribed = false;
+  }
+
+  getSnapshot(): EventSupervisorSnapshot {
+    return {
+      directory: this.currentDirectory,
+      isSubscribed: this.isSubscribed,
+    };
+  }
+
+  private onEvent(event: Event): void {
+    this.options.summaryAggregator.processEvent(event);
+
+    const eventType = getString((event as { type?: unknown }).type);
+    if (
+      eventType !== "question.replied" &&
+      eventType !== "question.rejected" &&
+      eventType !== "permission.replied"
+    ) {
+      return;
+    }
+
+    const requestId = getRequestId(event);
+    if (!requestId) {
+      return;
+    }
+
+    this.options.pendingStore.remove(requestId);
+  }
+
+  private async bootstrap(directory: string): Promise<void> {
+    if (!this.options.client) {
+      return;
+    }
+
+    try {
+      const questionResponse = await this.options.client.question.list({
+        directory,
+      });
+      const questions = questionResponse.data ?? [];
+      for (const item of questions) {
+        this.options.pendingStore.add(
+          item.id,
+          item.sessionID,
+          directory,
+          "",
+          "question",
+        );
+      }
+      this.options.logger.info(
+        `[EventSupervisor] Hydrated ${questions.length} pending question requests for ${directory}`,
+      );
+    } catch (error) {
+      this.options.logger.error(
+        `[EventSupervisor] Failed to hydrate pending question requests for ${directory}`,
+        error,
+      );
+    }
+
+    try {
+      const permissionResponse = await this.options.client.permission.list({
+        directory,
+      });
+      const permissions = permissionResponse.data ?? [];
+      for (const item of permissions) {
+        this.options.pendingStore.add(
+          item.id,
+          item.sessionID,
+          directory,
+          "",
+          "permission",
+        );
+      }
+      this.options.logger.info(
+        `[EventSupervisor] Hydrated ${permissions.length} pending permission requests for ${directory}`,
+      );
+    } catch (error) {
+      this.options.logger.error(
+        `[EventSupervisor] Failed to hydrate pending permission requests for ${directory}`,
+        error,
+      );
+    }
+  }
+}

--- a/src/events/supervisor.ts
+++ b/src/events/supervisor.ts
@@ -1,5 +1,8 @@
 import type { Event } from "@opencode-ai/sdk/v2";
-import type { OpenCodeEventSubscriber } from "../opencode/events.js";
+import {
+  FATAL_NO_STREAM_ERROR,
+  type OpenCodeEventSubscriber,
+} from "../opencode/events.js";
 import type { PendingInteractionStore } from "../pending/store.js";
 import type { Logger } from "../utils/logger.js";
 
@@ -26,6 +29,7 @@ export interface EventSupervisorOptions {
   pendingStore: PendingInteractionStore;
   client?: EventSupervisorClient;
   logger: Logger;
+  onFatalSubscriptionError?: (directory: string, error: unknown) => void;
   resubscribeDelayMs?: number;
 }
 
@@ -50,6 +54,10 @@ function getRequestId(event: Event): string | undefined {
     ? rawEvent.properties
     : undefined;
   return getString(properties?.requestID) ?? getString(properties?.id);
+}
+
+function isFatalSubscriptionError(error: unknown): boolean {
+  return error instanceof Error && error.message === FATAL_NO_STREAM_ERROR;
 }
 
 export class EventSupervisor {
@@ -118,6 +126,14 @@ export class EventSupervisor {
         );
 
         if (!this.isCurrentSubscription(directory, generation)) {
+          return;
+        }
+
+        if (isFatalSubscriptionError(error)) {
+          this.clearRetryTimer();
+          this.currentDirectory = null;
+          this.isSubscribed = false;
+          this.options.onFatalSubscriptionError?.(directory, error);
           return;
         }
 

--- a/src/feishu/handlers/permission.ts
+++ b/src/feishu/handlers/permission.ts
@@ -1,7 +1,6 @@
-import type { PermissionRequest } from "../../permission/types.js";
 import type { PermissionManager } from "../../permission/manager.js";
-import type { Logger } from "../../utils/logger.js";
-import { logger as defaultLogger } from "../../utils/logger.js";
+import type { PermissionRequest } from "../../permission/types.js";
+import { logger as defaultLogger, type Logger } from "../../utils/logger.js";
 
 type OpenCodeReplyValue = "once" | "always" | "reject";
 
@@ -27,15 +26,6 @@ export interface PermissionCardHandlerOptions {
   openCodeClient: OpenCodePermissionClient;
   interactionManager?: { clear(chatId: string, reason?: string): void };
   logger?: Logger;
-}
-
-function extractReceiveId(event: Record<string, unknown>): string | null {
-  const context = isRecord(event.context) ? event.context : null;
-  return typeof event.open_chat_id === "string"
-    ? event.open_chat_id
-    : typeof context?.open_chat_id === "string"
-      ? context.open_chat_id
-      : null;
 }
 
 function mapPermissionReply(cardReply: string): OpenCodeReplyValue {
@@ -159,6 +149,13 @@ export class PermissionCardHandler {
       return this.emptyResponse;
     }
 
+    if (this.permissionManager.isReplied(request.id)) {
+      this.logger.debug(
+        `[PermissionCardHandler] Ignoring already-replied card action for requestId=${request.id}, messageId=${messageId}`,
+      );
+      return this.emptyResponse;
+    }
+
     // Verify the request ID matches (extra safety check)
     if (request.id !== requestIdFromCard) {
       this.logger.warn(
@@ -174,18 +171,13 @@ export class PermissionCardHandler {
         requestID: request.id,
         reply,
       });
+      this.permissionManager.markReplied(request.id);
     } catch (error) {
       this.logger.error(
         `[PermissionCardHandler] Failed to forward permission reply for request ${request.id}`,
         error,
       );
       return this.emptyResponse;
-    }
-
-    this.permissionManager.removeByMessageId(messageId);
-    const receiveId = extractReceiveId(event);
-    if (receiveId) {
-      this.interactionManager?.clear(receiveId, "permission_resolved");
     }
 
     this.logger.info(

--- a/src/feishu/handlers/question.ts
+++ b/src/feishu/handlers/question.ts
@@ -318,6 +318,13 @@ export class QuestionCardHandler {
       return;
     }
 
+    if (this.questionManager.isSubmitted(requestID)) {
+      this.logger.debug(
+        `[QuestionCardHandler] Ignoring duplicate question submission for request ${requestID}`,
+      );
+      return;
+    }
+
     const answers = this.questionManager.getAllAnswerValues();
 
     const missingIndex = answers.findIndex((answer) => answer.length === 0);
@@ -328,10 +335,17 @@ export class QuestionCardHandler {
       return;
     }
 
-    await this.openCodeClient.question.reply({
-      requestID,
-      answers,
-    });
+    this.questionManager.markSubmitted(requestID);
+
+    try {
+      await this.openCodeClient.question.reply({
+        requestID,
+        answers,
+      });
+    } catch (error) {
+      this.questionManager.clearSubmitted(requestID);
+      throw error;
+    }
 
     this.logger.debug(
       `[QuestionCardHandler] Forwarded ${answers.length} answers for request ${requestID}`,

--- a/src/feishu/handlers/question.ts
+++ b/src/feishu/handlers/question.ts
@@ -337,10 +337,6 @@ export class QuestionCardHandler {
       `[QuestionCardHandler] Forwarded ${answers.length} answers for request ${requestID}`,
     );
 
-    this.questionManager.clear();
-    if (this.interactionManager && this.activeReceiveId) {
-      this.interactionManager.clear(this.activeReceiveId, "question_answered");
-    }
     this.activeReceiveId = null;
     this.activeSourceMessageId = null;
   }

--- a/src/feishu/response-pipeline.ts
+++ b/src/feishu/response-pipeline.ts
@@ -612,6 +612,21 @@ export class ResponsePipelineController {
     };
   }
 
+  handleEventSupervisorFailure(directory: string, error: unknown): void {
+    const affectedStates = this.getActiveStatesForDirectory(directory);
+
+    this.logger.error(
+      `[ResponsePipeline] Fatal event subscription failure for directory=${directory}; affectedSessions=${affectedStates.length}`,
+      error,
+    );
+
+    for (const state of affectedStates) {
+      void this.enqueueSessionTask(state.sessionId, () =>
+        this.handleSessionError(state.sessionId, STREAM_ENDED_MESSAGE()),
+      );
+    }
+  }
+
   startTurn(context: ResponsePipelineTurnContext): void {
     this.summaryAggregator.setSession(context.sessionId);
 
@@ -1359,6 +1374,16 @@ export class ResponsePipelineController {
     if (!this.eventSupervisor) {
       state.subscriptionAbortController?.abort();
     }
+  }
+
+  private getActiveStatesForDirectory(directory: string): StatusTurnState[] {
+    return this.statusStore
+      .getSessionIds()
+      .map((sessionId) => this.statusStore.get(sessionId))
+      .filter(
+        (state): state is StatusTurnState =>
+          state !== undefined && state.directory === directory,
+      );
   }
 
   private getStatusCardContent(state: StatusTurnState): string {

--- a/src/feishu/response-pipeline.ts
+++ b/src/feishu/response-pipeline.ts
@@ -88,6 +88,9 @@ export interface SessionMessageFetcher {
 
 export interface ResponsePipelineControllerOptions {
   eventSubscriber?: ResponsePipelineEventSubscriber;
+  eventSupervisor?: {
+    ensureSubscribed(directory: string): void;
+  };
   summaryAggregator?: ResponsePipelineSummaryAggregator;
   sessionMessageFetcher?: SessionMessageFetcher;
   renderer: ResponsePipelineRenderer;
@@ -511,6 +514,9 @@ export function isRetryableStatusCardUpdateError(error: unknown): boolean {
 
 export class ResponsePipelineController {
   private readonly eventSubscriber: ResponsePipelineEventSubscriber;
+  private readonly eventSupervisor: {
+    ensureSubscribed(directory: string): void;
+  } | null;
   private readonly summaryAggregator: ResponsePipelineSummaryAggregator;
   private readonly sessionMessageFetcher?: SessionMessageFetcher;
   private readonly renderer: ResponsePipelineRenderer;
@@ -533,6 +539,7 @@ export class ResponsePipelineController {
         : getConfig();
 
     this.eventSubscriber = options.eventSubscriber ?? openCodeEventSubscriber;
+    this.eventSupervisor = options.eventSupervisor ?? null;
     this.summaryAggregator =
       options.summaryAggregator ?? defaultSummaryAggregator;
     this.sessionMessageFetcher = options.sessionMessageFetcher;
@@ -608,17 +615,20 @@ export class ResponsePipelineController {
   startTurn(context: ResponsePipelineTurnContext): void {
     this.summaryAggregator.setSession(context.sessionId);
 
-    const abortController = new AbortController();
     const state = this.statusStore.startTurn(context);
-    state.subscriptionAbortController = abortController;
 
     this.logger.info(
       `[ResponsePipeline] Starting turn: session=${context.sessionId}, directory=${context.directory}, receiveId=${context.receiveId}, sourceMessageId=${context.sourceMessageId}`,
     );
 
-    this.scheduleAsync(() => {
-      void this.runEventSubscription(context, abortController);
-    });
+    if (this.eventSupervisor) {
+      this.eventSupervisor.ensureSubscribed(context.directory);
+      return;
+    }
+
+    const abortController = new AbortController();
+    state.subscriptionAbortController = abortController;
+    void this.runEventSubscription(context, abortController);
   }
 
   async recordFollowUpAppended(
@@ -1346,7 +1356,9 @@ export class ResponsePipelineController {
 
   private disposeTurnResources(state: StatusTurnState): void {
     this.clearScheduledStatusUpdate(state);
-    state.subscriptionAbortController?.abort();
+    if (!this.eventSupervisor) {
+      state.subscriptionAbortController?.abort();
+    }
   }
 
   private getStatusCardContent(state: StatusTurnState): string {

--- a/src/interaction/manager.ts
+++ b/src/interaction/manager.ts
@@ -1,3 +1,4 @@
+import { logger } from "../utils/logger.js";
 import type {
   BlockReason,
   BusyState,
@@ -12,7 +13,6 @@ import type {
   StartInteractionOptions,
   TransitionInteractionOptions,
 } from "./types.js";
-import { logger } from "../utils/logger.js";
 
 export const DEFAULT_ALLOWED_INTERACTION_COMMANDS = [
   "/help",
@@ -456,5 +456,3 @@ export class InteractionManager {
     );
   }
 }
-
-export const interactionManager = new InteractionManager();

--- a/src/pending/store.ts
+++ b/src/pending/store.ts
@@ -1,0 +1,93 @@
+import type { PendingRequest, PendingRequestType } from "./types.js";
+
+export class PendingInteractionStore {
+  private readonly byRequestId = new Map<string, PendingRequest>();
+
+  add(
+    requestId: string,
+    sessionId: string,
+    directory: string,
+    chatId: string,
+    type: PendingRequestType,
+  ): PendingRequest {
+    const existing = this.byRequestId.get(requestId);
+    if (existing) {
+      return existing;
+    }
+
+    const entry: PendingRequest = {
+      requestId,
+      sessionId,
+      directory,
+      chatId,
+      type,
+      cardMessageId: null,
+      createdAt: Date.now(),
+    };
+    this.byRequestId.set(requestId, entry);
+    return entry;
+  }
+
+  setCardMessageId(requestId: string, cardMessageId: string): boolean {
+    const entry = this.byRequestId.get(requestId);
+    if (!entry) {
+      return false;
+    }
+    entry.cardMessageId = cardMessageId;
+    return true;
+  }
+
+  get(requestId: string): PendingRequest | undefined {
+    return this.byRequestId.get(requestId);
+  }
+
+  getBySessionId(sessionId: string): PendingRequest[] {
+    const result: PendingRequest[] = [];
+    for (const entry of this.byRequestId.values()) {
+      if (entry.sessionId === sessionId) {
+        result.push(entry);
+      }
+    }
+    return result;
+  }
+
+  getByCardMessageId(cardMessageId: string): PendingRequest | undefined {
+    for (const entry of this.byRequestId.values()) {
+      if (entry.cardMessageId === cardMessageId) {
+        return entry;
+      }
+    }
+    return undefined;
+  }
+
+  remove(requestId: string): boolean {
+    return this.byRequestId.delete(requestId);
+  }
+
+  removeBySessionId(sessionId: string): number {
+    let removed = 0;
+    for (const [requestId, entry] of this.byRequestId) {
+      if (entry.sessionId === sessionId) {
+        this.byRequestId.delete(requestId);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  has(requestId: string): boolean {
+    return this.byRequestId.has(requestId);
+  }
+
+  size(): number {
+    return this.byRequestId.size;
+  }
+
+  getAll(): PendingRequest[] {
+    return [...this.byRequestId.values()];
+  }
+
+  clear(): void {
+    this.byRequestId.clear();
+  }
+}

--- a/src/pending/types.ts
+++ b/src/pending/types.ts
@@ -1,0 +1,11 @@
+export type PendingRequestType = "question" | "permission";
+
+export interface PendingRequest {
+  requestId: string;
+  sessionId: string;
+  directory: string;
+  chatId: string;
+  type: PendingRequestType;
+  cardMessageId: string | null;
+  createdAt: number;
+}

--- a/src/permission/manager.ts
+++ b/src/permission/manager.ts
@@ -1,10 +1,12 @@
-import type { PermissionRequest, PermissionState } from "./types.js";
 import { logger } from "../utils/logger.js";
+import type { PermissionRequest, PermissionState } from "./types.js";
 
 export class PermissionManager {
   private state: PermissionState = {
     requestsByMessageId: new Map(),
   };
+
+  private repliedRequestIds: Set<string> = new Set();
 
   getStateSnapshot(): PermissionState {
     return {
@@ -53,6 +55,14 @@ export class PermissionManager {
     return messageId !== null && this.state.requestsByMessageId.has(messageId);
   }
 
+  markReplied(requestId: string): void {
+    this.repliedRequestIds.add(requestId);
+  }
+
+  isReplied(requestId: string): boolean {
+    return this.repliedRequestIds.has(requestId);
+  }
+
   getMessageId(): string | null {
     const messageIds = this.getMessageIds();
     if (messageIds.length === 0) {
@@ -73,11 +83,38 @@ export class PermissionManager {
     }
 
     this.state.requestsByMessageId.delete(messageId);
+    this.repliedRequestIds.delete(request.id);
     logger.debug(
       `[PermissionManager] Removed permission request: id=${request.id}, messageId=${messageId}, pending=${this.state.requestsByMessageId.size}`,
     );
 
     return request;
+  }
+
+  removeByRequestId(requestId: string | null): PermissionRequest | null {
+    if (requestId === null) {
+      return null;
+    }
+
+    this.repliedRequestIds.delete(requestId);
+
+    for (const [
+      messageId,
+      request,
+    ] of this.state.requestsByMessageId.entries()) {
+      if (request.id !== requestId) {
+        continue;
+      }
+
+      this.state.requestsByMessageId.delete(messageId);
+      logger.debug(
+        `[PermissionManager] Removed permission request: id=${request.id}, messageId=${messageId}, pending=${this.state.requestsByMessageId.size}`,
+      );
+
+      return request;
+    }
+
+    return null;
   }
 
   getPendingCount(): number {
@@ -95,7 +132,6 @@ export class PermissionManager {
     this.state = {
       requestsByMessageId: new Map(),
     };
+    this.repliedRequestIds.clear();
   }
 }
-
-export const permissionManager = new PermissionManager();

--- a/src/question/manager.ts
+++ b/src/question/manager.ts
@@ -21,6 +21,8 @@ function cloneState(state: QuestionState): QuestionState {
 }
 
 export class QuestionManager {
+  private submittedRequestIds: Set<string> = new Set();
+
   private state: QuestionState = {
     questions: [],
     currentIndex: 0,
@@ -256,6 +258,19 @@ export class QuestionManager {
       isActive: false,
       requestID: null,
     };
+    this.submittedRequestIds.clear();
+  }
+
+  markSubmitted(requestId: string): void {
+    this.submittedRequestIds.add(requestId);
+  }
+
+  clearSubmitted(requestId: string): void {
+    this.submittedRequestIds.delete(requestId);
+  }
+
+  isSubmitted(requestId: string): boolean {
+    return this.submittedRequestIds.has(requestId);
   }
 
   getAllAnswers(): QuestionAnswer[] {

--- a/src/question/manager.ts
+++ b/src/question/manager.ts
@@ -1,5 +1,5 @@
-import type { Question, QuestionAnswer, QuestionState } from "./types.js";
 import { logger } from "../utils/logger.js";
+import type { Question, QuestionAnswer, QuestionState } from "./types.js";
 
 function cloneState(state: QuestionState): QuestionState {
   return {
@@ -293,5 +293,3 @@ export class QuestionManager {
     return answers;
   }
 }
-
-export const questionManager = new QuestionManager();

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -1,20 +1,11 @@
-export {
-  SessionManager,
-  clearChatSession,
-  clearSession,
-  getChatSession,
-  getCurrentSession,
-  sessionManager,
-  setChatSession,
-  setCurrentSession,
-} from "./manager.js";
 export type { SessionInfo, SessionStore } from "./manager.js";
+export { SessionManager } from "./manager.js";
+export type {
+  SessionHistoryContext,
+  SessionPreviewMessage,
+} from "./session-history.js";
 export {
   formatSessionPreview,
   loadContextFromHistory,
   loadSessionPreview,
-} from "./session-history.js";
-export type {
-  SessionHistoryContext,
-  SessionPreviewMessage,
 } from "./session-history.js";

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1,8 +1,4 @@
-import {
-  settingsManager,
-  type SessionInfo,
-  type SettingsManager,
-} from "../settings/manager.js";
+import type { SessionInfo, SettingsManager } from "../settings/manager.js";
 
 export type { SessionInfo };
 
@@ -16,9 +12,7 @@ export interface SessionStore {
 }
 
 export class SessionManager {
-  constructor(
-    private readonly store: SessionStore = settingsManager as SettingsManager,
-  ) {}
+  constructor(private readonly store: SessionStore | SettingsManager) {}
 
   setCurrentSession(sessionInfo: SessionInfo): void {
     this.store.setCurrentSession(sessionInfo);
@@ -43,30 +37,4 @@ export class SessionManager {
   clearChatSession(chatId: string): void {
     this.store.clearChatSession(chatId);
   }
-}
-
-export const sessionManager = new SessionManager();
-
-export function setCurrentSession(sessionInfo: SessionInfo): void {
-  sessionManager.setCurrentSession(sessionInfo);
-}
-
-export function getCurrentSession(): SessionInfo | null {
-  return sessionManager.getCurrentSession();
-}
-
-export function clearSession(): void {
-  sessionManager.clearSession();
-}
-
-export function setChatSession(chatId: string, sessionInfo: SessionInfo): void {
-  sessionManager.setChatSession(chatId, sessionInfo);
-}
-
-export function getChatSession(chatId: string): SessionInfo | undefined {
-  return sessionManager.getChatSession(chatId);
-}
-
-export function clearChatSession(chatId: string): void {
-  sessionManager.clearChatSession(chatId);
 }

--- a/src/settings/manager.ts
+++ b/src/settings/manager.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { logger as defaultLogger, type Logger } from "../utils/logger.js";
 
 export interface ProjectInfo {
@@ -413,127 +413,127 @@ export class SettingsManager {
   }
 }
 
-export const settingsManager = new SettingsManager();
+const defaultSettingsManager = new SettingsManager();
 
 export function getSettingsFilePath(): string {
-  return settingsManager.getSettingsFilePath();
+  return defaultSettingsManager.getSettingsFilePath();
 }
 
 export async function loadSettings(): Promise<void> {
-  return settingsManager.loadSettings();
+  return defaultSettingsManager.loadSettings();
 }
 
 export function getCurrentProject(): ProjectInfo | undefined {
-  return settingsManager.getCurrentProject();
+  return defaultSettingsManager.getCurrentProject();
 }
 
 export function setCurrentProject(projectInfo: ProjectInfo): void {
-  settingsManager.setCurrentProject(projectInfo);
+  defaultSettingsManager.setCurrentProject(projectInfo);
 }
 
 export function clearProject(): void {
-  settingsManager.clearProject();
+  defaultSettingsManager.clearProject();
 }
 
 export function getCurrentSession(): SessionInfo | undefined {
-  return settingsManager.getCurrentSession();
+  return defaultSettingsManager.getCurrentSession();
 }
 
 export function setCurrentSession(sessionInfo: SessionInfo): void {
-  settingsManager.setCurrentSession(sessionInfo);
+  defaultSettingsManager.setCurrentSession(sessionInfo);
 }
 
 export function clearSession(): void {
-  settingsManager.clearSession();
+  defaultSettingsManager.clearSession();
 }
 
 export function getChatSession(chatId: string): SessionInfo | undefined {
-  return settingsManager.getChatSession(chatId);
+  return defaultSettingsManager.getChatSession(chatId);
 }
 
 export function setChatSession(chatId: string, sessionInfo: SessionInfo): void {
-  settingsManager.setChatSession(chatId, sessionInfo);
+  defaultSettingsManager.setChatSession(chatId, sessionInfo);
 }
 
 export function clearChatSession(chatId: string): void {
-  settingsManager.clearChatSession(chatId);
+  defaultSettingsManager.clearChatSession(chatId);
 }
 
 export function getCurrentAgent(): string | undefined {
-  return settingsManager.getCurrentAgent();
+  return defaultSettingsManager.getCurrentAgent();
 }
 
 export function setCurrentAgent(agentName: string): void {
-  settingsManager.setCurrentAgent(agentName);
+  defaultSettingsManager.setCurrentAgent(agentName);
 }
 
 export function clearCurrentAgent(): void {
-  settingsManager.clearCurrentAgent();
+  defaultSettingsManager.clearCurrentAgent();
 }
 
 export function getCurrentModel(): ModelInfo | undefined {
-  return settingsManager.getCurrentModel();
+  return defaultSettingsManager.getCurrentModel();
 }
 
 export function setCurrentModel(modelInfo: ModelInfo): void {
-  settingsManager.setCurrentModel(modelInfo);
+  defaultSettingsManager.setCurrentModel(modelInfo);
 }
 
 export function clearCurrentModel(): void {
-  settingsManager.clearCurrentModel();
+  defaultSettingsManager.clearCurrentModel();
 }
 
 export function getStatusMessageId(): string | undefined {
-  return settingsManager.getStatusMessageId();
+  return defaultSettingsManager.getStatusMessageId();
 }
 
 export function setStatusMessageId(messageId: string): void {
-  settingsManager.setStatusMessageId(messageId);
+  defaultSettingsManager.setStatusMessageId(messageId);
 }
 
 export function clearStatusMessageId(): void {
-  settingsManager.clearStatusMessageId();
+  defaultSettingsManager.clearStatusMessageId();
 }
 
 export function getChatStatusMessageId(chatId: string): string | undefined {
-  return settingsManager.getChatStatusMessageId(chatId);
+  return defaultSettingsManager.getChatStatusMessageId(chatId);
 }
 
 export function setChatStatusMessageId(
   chatId: string,
   messageId: string,
 ): void {
-  settingsManager.setChatStatusMessageId(chatId, messageId);
+  defaultSettingsManager.setChatStatusMessageId(chatId, messageId);
 }
 
 export function clearChatStatusMessageId(chatId: string): void {
-  settingsManager.clearChatStatusMessageId(chatId);
+  defaultSettingsManager.clearChatStatusMessageId(chatId);
 }
 
 export function getSessionDirectoryCache():
   | SessionDirectoryCacheInfo
   | undefined {
-  return settingsManager.getSessionDirectoryCache();
+  return defaultSettingsManager.getSessionDirectoryCache();
 }
 
 export function setSessionDirectoryCache(
   cache: SessionDirectoryCacheInfo,
 ): Promise<void> {
-  return settingsManager.setSessionDirectoryCache(cache);
+  return defaultSettingsManager.setSessionDirectoryCache(cache);
 }
 
 export function clearSessionDirectoryCache(): void {
-  settingsManager.clearSessionDirectoryCache();
+  defaultSettingsManager.clearSessionDirectoryCache();
 }
 
 export async function waitForPendingSettingsWrites(): Promise<void> {
-  return settingsManager.waitForPendingWrites();
+  return defaultSettingsManager.waitForPendingWrites();
 }
 
 export function __resetSettingsForTests(): void {
-  settingsManager.__resetSettingsForTests();
+  defaultSettingsManager.__resetSettingsForTests();
 }
 
 export function __resetChatStateForTests(): void {
-  settingsManager.__resetChatStateForTests();
+  defaultSettingsManager.__resetChatStateForTests();
 }

--- a/src/summary/aggregator.ts
+++ b/src/summary/aggregator.ts
@@ -230,10 +230,28 @@ export class SummaryAggregator {
     this.callbacks.onQuestionError = callback;
   }
 
+  setOnQuestionReplied(
+    callback: NonNullable<SummaryCallbacks["onQuestionReplied"]>,
+  ): void {
+    this.callbacks.onQuestionReplied = callback;
+  }
+
+  setOnQuestionRejected(
+    callback: NonNullable<SummaryCallbacks["onQuestionRejected"]>,
+  ): void {
+    this.callbacks.onQuestionRejected = callback;
+  }
+
   setOnPermission(
     callback: NonNullable<SummaryCallbacks["onPermission"]>,
   ): void {
     this.callbacks.onPermission = callback;
+  }
+
+  setOnPermissionReplied(
+    callback: NonNullable<SummaryCallbacks["onPermissionReplied"]>,
+  ): void {
+    this.callbacks.onPermissionReplied = callback;
   }
 
   setOnSessionDiff(
@@ -311,8 +329,17 @@ export class SummaryAggregator {
       case "question.asked":
         this.handleQuestionAsked(event);
         break;
+      case "question.replied":
+        this.handleQuestionReplied(event);
+        break;
+      case "question.rejected":
+        this.handleQuestionRejected(event);
+        break;
       case "permission.asked":
         this.handlePermissionAsked(event);
+        break;
+      case "permission.replied":
+        this.handlePermissionReplied(event);
         break;
       case "session.diff":
         this.handleSessionDiff(event);
@@ -672,6 +699,54 @@ export class SummaryAggregator {
 
     this.scheduleAsync(() => {
       this.callbacks.onPermission?.(permissionEvent);
+    });
+  }
+
+  private handleQuestionReplied(event: Event): void {
+    const properties = getEventProperties(event);
+    const sessionId = properties && getString(properties.sessionID);
+    const requestId =
+      (properties && getString(properties.requestID)) ||
+      (properties && getString(properties.id));
+
+    if (!sessionId || !requestId || sessionId !== this.currentSessionId) {
+      return;
+    }
+
+    this.scheduleAsync(() => {
+      this.callbacks.onQuestionReplied?.(sessionId, requestId);
+    });
+  }
+
+  private handleQuestionRejected(event: Event): void {
+    const properties = getEventProperties(event);
+    const sessionId = properties && getString(properties.sessionID);
+    const requestId =
+      (properties && getString(properties.requestID)) ||
+      (properties && getString(properties.id));
+
+    if (!sessionId || !requestId || sessionId !== this.currentSessionId) {
+      return;
+    }
+
+    this.scheduleAsync(() => {
+      this.callbacks.onQuestionRejected?.(sessionId, requestId);
+    });
+  }
+
+  private handlePermissionReplied(event: Event): void {
+    const properties = getEventProperties(event);
+    const sessionId = properties && getString(properties.sessionID);
+    const requestId =
+      (properties && getString(properties.requestID)) ||
+      (properties && getString(properties.id));
+
+    if (!sessionId || !requestId || sessionId !== this.currentSessionId) {
+      return;
+    }
+
+    this.scheduleAsync(() => {
+      this.callbacks.onPermissionReplied?.(sessionId, requestId);
     });
   }
 

--- a/src/summary/types.ts
+++ b/src/summary/types.ts
@@ -82,7 +82,10 @@ export interface SummaryCallbacks {
   onTool?: (toolEvent: SummaryToolEvent) => void;
   onQuestion?: (questionEvent: SummaryQuestionEvent) => void;
   onQuestionError?: (sessionId: string) => void;
+  onQuestionReplied?: (sessionId: string, requestId: string) => void;
+  onQuestionRejected?: (sessionId: string, requestId: string) => void;
   onPermission?: (permissionEvent: SummaryPermissionEvent) => void;
+  onPermissionReplied?: (sessionId: string, requestId: string) => void;
   onSessionDiff?: (diffEvent: SummarySessionDiffEvent) => void;
   onTokenUpdate?: (tokenEvent: SummaryTokenEvent) => void;
   onSessionRetry?: (retryInfo: SummarySessionRetryInfo) => void;

--- a/tests/unit/event-supervisor.test.ts
+++ b/tests/unit/event-supervisor.test.ts
@@ -89,6 +89,7 @@ describe("EventSupervisor", () => {
       pendingStore,
       client,
       logger,
+      resubscribeDelayMs: 5,
     });
   });
 
@@ -216,6 +217,57 @@ describe("EventSupervisor", () => {
       chatId: "",
       type: "permission",
     });
+  });
+
+  it("bootstrap does not hydrate stale directory after subscription switch", async () => {
+    const questionResolvers = new Map<
+      string,
+      (value: { data: Array<{ id: string; sessionID: string }> }) => void
+    >();
+    client.question.list = vi.fn().mockImplementation(
+      ({ directory }: { directory?: string } = {}) =>
+        new Promise<{ data: Array<{ id: string; sessionID: string }> }>(
+          (resolve) => {
+            if (directory) {
+              questionResolvers.set(directory, resolve);
+            }
+          },
+        ),
+    );
+    client.permission.list = vi.fn().mockResolvedValue({ data: [] });
+
+    supervisor.ensureSubscribed("/workspace/a");
+    supervisor.ensureSubscribed("/workspace/b");
+
+    const resolveWorkspaceA = questionResolvers.get("/workspace/a");
+    expect(resolveWorkspaceA).toBeDefined();
+    resolveWorkspaceA?.({ data: [{ id: "q-stale", sessionID: "sess-a" }] });
+    await flushPromises();
+
+    expect(pendingStore.has("q-stale")).toBe(false);
+  });
+
+  it("retries subscription after subscribeToEvents rejects", async () => {
+    vi.useFakeTimers();
+    subscribeToEvents.mockRejectedValueOnce(new Error("no stream"));
+
+    try {
+      supervisor.ensureSubscribed("/workspace/a");
+      await flushPromises();
+
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(subscribeToEvents).toHaveBeenCalledTimes(2);
+      expect(subscribeToEvents).toHaveBeenNthCalledWith(
+        2,
+        "/workspace/a",
+        expect.any(Function),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("bootstrap failure is logged but does not crash", async () => {

--- a/tests/unit/event-supervisor.test.ts
+++ b/tests/unit/event-supervisor.test.ts
@@ -1,0 +1,269 @@
+import type { Event } from "@opencode-ai/sdk/v2";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventSupervisor } from "../../src/events/supervisor.js";
+import type {
+  OpenCodeEventSubscriber,
+  SubscribeToEventsOptions,
+} from "../../src/opencode/events.js";
+import { PendingInteractionStore } from "../../src/pending/store.js";
+import type { Logger } from "../../src/utils/logger.js";
+
+type EventCallback = (event: Event) => void;
+
+type EventSupervisorClient = NonNullable<
+  ConstructorParameters<typeof EventSupervisor>[0]["client"]
+>;
+
+function makeEvent(
+  type: string,
+  properties: Record<string, unknown> = {},
+): Event {
+  return {
+    type,
+    properties,
+  } as unknown as Event;
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("EventSupervisor", () => {
+  let subscribeToEvents: ReturnType<typeof vi.fn>;
+  let stopEventListening: ReturnType<typeof vi.fn>;
+  let eventSubscriber: Pick<
+    OpenCodeEventSubscriber,
+    "subscribeToEvents" | "stopEventListening"
+  >;
+  let summaryAggregator: { processEvent: ReturnType<typeof vi.fn> };
+  let pendingStore: PendingInteractionStore;
+  let client: EventSupervisorClient;
+  let logger: Logger;
+  let supervisor: EventSupervisor;
+
+  beforeEach(() => {
+    subscribeToEvents = vi
+      .fn<
+        (
+          directory: string,
+          callback: EventCallback,
+          options?: SubscribeToEventsOptions,
+        ) => Promise<void>
+      >()
+      .mockResolvedValue(undefined);
+    stopEventListening = vi.fn();
+
+    eventSubscriber = {
+      subscribeToEvents:
+        subscribeToEvents as OpenCodeEventSubscriber["subscribeToEvents"],
+      stopEventListening:
+        stopEventListening as OpenCodeEventSubscriber["stopEventListening"],
+    };
+
+    summaryAggregator = {
+      processEvent: vi.fn(),
+    };
+
+    pendingStore = new PendingInteractionStore();
+
+    client = {
+      question: {
+        list: vi.fn().mockResolvedValue({ data: [] }),
+      },
+      permission: {
+        list: vi.fn().mockResolvedValue({ data: [] }),
+      },
+    };
+
+    logger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    supervisor = new EventSupervisor({
+      eventSubscriber: eventSubscriber as OpenCodeEventSubscriber,
+      summaryAggregator,
+      pendingStore,
+      client,
+      logger,
+    });
+  });
+
+  it("ensureSubscribed starts subscription for new directory", () => {
+    supervisor.ensureSubscribed("/workspace/a");
+
+    expect(eventSubscriber.subscribeToEvents).toHaveBeenCalledWith(
+      "/workspace/a",
+      expect.any(Function),
+    );
+  });
+
+  it("ensureSubscribed is no-op for same directory", () => {
+    supervisor.ensureSubscribed("/workspace/a");
+    supervisor.ensureSubscribed("/workspace/a");
+
+    expect(eventSubscriber.subscribeToEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it("ensureSubscribed restarts for different directory", () => {
+    supervisor.ensureSubscribed("/workspace/a");
+    supervisor.ensureSubscribed("/workspace/b");
+
+    expect(eventSubscriber.stopEventListening).toHaveBeenCalledTimes(1);
+    expect(eventSubscriber.subscribeToEvents).toHaveBeenNthCalledWith(
+      2,
+      "/workspace/b",
+      expect.any(Function),
+    );
+  });
+
+  it("onEvent forwards all events to summaryAggregator", () => {
+    supervisor.ensureSubscribed("/workspace/a");
+
+    const callback = subscribeToEvents.mock.calls[0]?.[1];
+    const event = makeEvent("message.updated", { id: "msg-1" });
+    callback?.(event);
+
+    expect(summaryAggregator.processEvent).toHaveBeenCalledWith(event);
+  });
+
+  it("onEvent removes from pendingStore on question.replied", () => {
+    pendingStore.add("req-1", "sess-1", "/workspace/a", "chat-1", "question");
+    supervisor.ensureSubscribed("/workspace/a");
+
+    const callback = subscribeToEvents.mock.calls[0]?.[1];
+    callback?.(
+      makeEvent("question.replied", {
+        sessionID: "sess-1",
+        requestID: "req-1",
+      }),
+    );
+
+    expect(pendingStore.has("req-1")).toBe(false);
+  });
+
+  it("onEvent removes from pendingStore on question.rejected", () => {
+    pendingStore.add("req-1", "sess-1", "/workspace/a", "chat-1", "question");
+    supervisor.ensureSubscribed("/workspace/a");
+
+    const callback = subscribeToEvents.mock.calls[0]?.[1];
+    callback?.(
+      makeEvent("question.rejected", {
+        sessionID: "sess-1",
+        id: "req-1",
+      }),
+    );
+
+    expect(pendingStore.has("req-1")).toBe(false);
+  });
+
+  it("onEvent removes from pendingStore on permission.replied", () => {
+    pendingStore.add("req-1", "sess-1", "/workspace/a", "chat-1", "permission");
+    supervisor.ensureSubscribed("/workspace/a");
+
+    const callback = subscribeToEvents.mock.calls[0]?.[1];
+    callback?.(
+      makeEvent("permission.replied", {
+        sessionID: "sess-1",
+        requestID: "req-1",
+      }),
+    );
+
+    expect(pendingStore.has("req-1")).toBe(false);
+  });
+
+  it("onEvent does not touch pendingStore for other event types", () => {
+    pendingStore.add("req-1", "sess-1", "/workspace/a", "chat-1", "question");
+    supervisor.ensureSubscribed("/workspace/a");
+
+    const callback = subscribeToEvents.mock.calls[0]?.[1];
+    callback?.(makeEvent("message.updated", { id: "msg-1" }));
+
+    expect(pendingStore.has("req-1")).toBe(true);
+  });
+
+  it("bootstrap hydrates pendingStore from question.list and permission.list", async () => {
+    client.question.list = vi.fn().mockResolvedValue({
+      data: [{ id: "q-1", sessionID: "sess-q" }],
+    });
+    client.permission.list = vi.fn().mockResolvedValue({
+      data: [{ id: "p-1", sessionID: "sess-p" }],
+    });
+
+    supervisor.ensureSubscribed("/workspace/a");
+    await flushPromises();
+
+    expect(client.question.list).toHaveBeenCalledWith({
+      directory: "/workspace/a",
+    });
+    expect(client.permission.list).toHaveBeenCalledWith({
+      directory: "/workspace/a",
+    });
+    expect(pendingStore.get("q-1")).toMatchObject({
+      requestId: "q-1",
+      sessionId: "sess-q",
+      directory: "/workspace/a",
+      chatId: "",
+      type: "question",
+    });
+    expect(pendingStore.get("p-1")).toMatchObject({
+      requestId: "p-1",
+      sessionId: "sess-p",
+      directory: "/workspace/a",
+      chatId: "",
+      type: "permission",
+    });
+  });
+
+  it("bootstrap failure is logged but does not crash", async () => {
+    const failure = new Error("question list failed");
+    client.question.list = vi.fn().mockRejectedValue(failure);
+    client.permission.list = vi.fn().mockResolvedValue({
+      data: [{ id: "p-1", sessionID: "sess-p" }],
+    });
+
+    expect(() => supervisor.ensureSubscribed("/workspace/a")).not.toThrow();
+    await flushPromises();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "[EventSupervisor] Failed to hydrate pending question requests for /workspace/a",
+      failure,
+    );
+    expect(pendingStore.get("p-1")).toMatchObject({
+      requestId: "p-1",
+      type: "permission",
+    });
+  });
+
+  it("stop calls stopEventListening", () => {
+    supervisor.ensureSubscribed("/workspace/a");
+
+    supervisor.stop();
+
+    expect(eventSubscriber.stopEventListening).toHaveBeenCalledTimes(1);
+  });
+
+  it("getSnapshot returns current state", () => {
+    expect(supervisor.getSnapshot()).toEqual({
+      directory: null,
+      isSubscribed: false,
+    });
+
+    supervisor.ensureSubscribed("/workspace/a");
+
+    expect(supervisor.getSnapshot()).toEqual({
+      directory: "/workspace/a",
+      isSubscribed: true,
+    });
+
+    supervisor.stop();
+
+    expect(supervisor.getSnapshot()).toEqual({
+      directory: null,
+      isSubscribed: false,
+    });
+  });
+});

--- a/tests/unit/event-supervisor.test.ts
+++ b/tests/unit/event-supervisor.test.ts
@@ -5,6 +5,7 @@ import type {
   OpenCodeEventSubscriber,
   SubscribeToEventsOptions,
 } from "../../src/opencode/events.js";
+import { FATAL_NO_STREAM_ERROR } from "../../src/opencode/events.js";
 import { PendingInteractionStore } from "../../src/pending/store.js";
 import type { Logger } from "../../src/utils/logger.js";
 
@@ -40,6 +41,7 @@ describe("EventSupervisor", () => {
   let pendingStore: PendingInteractionStore;
   let client: EventSupervisorClient;
   let logger: Logger;
+  let onFatalSubscriptionError: ReturnType<typeof vi.fn>;
   let supervisor: EventSupervisor;
 
   beforeEach(() => {
@@ -83,12 +85,15 @@ describe("EventSupervisor", () => {
       error: vi.fn(),
     };
 
+    onFatalSubscriptionError = vi.fn();
+
     supervisor = new EventSupervisor({
       eventSubscriber: eventSubscriber as OpenCodeEventSubscriber,
       summaryAggregator,
       pendingStore,
       client,
       logger,
+      onFatalSubscriptionError,
       resubscribeDelayMs: 5,
     });
   });
@@ -249,7 +254,7 @@ describe("EventSupervisor", () => {
 
   it("retries subscription after subscribeToEvents rejects", async () => {
     vi.useFakeTimers();
-    subscribeToEvents.mockRejectedValueOnce(new Error("no stream"));
+    subscribeToEvents.mockRejectedValueOnce(new Error("temporary failure"));
 
     try {
       supervisor.ensureSubscribed("/workspace/a");
@@ -265,6 +270,31 @@ describe("EventSupervisor", () => {
         "/workspace/a",
         expect.any(Function),
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("propagates fatal no-stream failures without retrying", async () => {
+    vi.useFakeTimers();
+    const failure = new Error(FATAL_NO_STREAM_ERROR);
+    subscribeToEvents.mockRejectedValueOnce(failure);
+
+    try {
+      supervisor.ensureSubscribed("/workspace/a");
+      await flushPromises();
+
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(5);
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+      expect(onFatalSubscriptionError).toHaveBeenCalledWith(
+        "/workspace/a",
+        failure,
+      );
+      expect(supervisor.getSnapshot()).toEqual({
+        directory: null,
+        isSubscribed: false,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/tests/unit/pending-store.test.ts
+++ b/tests/unit/pending-store.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { PendingInteractionStore } from "../../src/pending/store.js";
+
+describe("PendingInteractionStore", () => {
+  let store: PendingInteractionStore;
+
+  beforeEach(() => {
+    store = new PendingInteractionStore();
+  });
+
+  it("adds and retrieves a pending request by requestId", () => {
+    const entry = store.add(
+      "req-1",
+      "sess-1",
+      "/workspace",
+      "chat-1",
+      "question",
+    );
+
+    expect(entry).toEqual({
+      requestId: "req-1",
+      sessionId: "sess-1",
+      directory: "/workspace",
+      chatId: "chat-1",
+      type: "question",
+      cardMessageId: null,
+      createdAt: expect.any(Number),
+    });
+    expect(store.get("req-1")).toBe(entry);
+    expect(store.size()).toBe(1);
+  });
+
+  it("returns existing entry when adding duplicate requestId", () => {
+    const first = store.add(
+      "req-1",
+      "sess-1",
+      "/workspace",
+      "chat-1",
+      "question",
+    );
+    const second = store.add(
+      "req-1",
+      "sess-2",
+      "/other",
+      "chat-2",
+      "permission",
+    );
+
+    expect(second).toBe(first);
+    expect(store.size()).toBe(1);
+    expect(store.get("req-1")?.sessionId).toBe("sess-1");
+  });
+
+  it("sets and retrieves card message ID", () => {
+    store.add("req-1", "sess-1", "/workspace", "chat-1", "question");
+
+    expect(store.setCardMessageId("req-1", "msg-card-1")).toBe(true);
+    expect(store.get("req-1")?.cardMessageId).toBe("msg-card-1");
+  });
+
+  it("returns false when setting card message ID for unknown request", () => {
+    expect(store.setCardMessageId("nonexistent", "msg-1")).toBe(false);
+  });
+
+  it("retrieves pending requests by session ID", () => {
+    store.add("req-1", "sess-1", "/workspace", "chat-1", "question");
+    store.add("req-2", "sess-1", "/workspace", "chat-1", "permission");
+    store.add("req-3", "sess-2", "/workspace", "chat-2", "question");
+
+    const sess1Requests = store.getBySessionId("sess-1");
+    expect(sess1Requests).toHaveLength(2);
+    expect(sess1Requests.map((r) => r.requestId).sort()).toEqual([
+      "req-1",
+      "req-2",
+    ]);
+  });
+
+  it("retrieves pending request by card message ID", () => {
+    store.add("req-1", "sess-1", "/workspace", "chat-1", "question");
+    store.setCardMessageId("req-1", "msg-card-1");
+
+    expect(store.getByCardMessageId("msg-card-1")?.requestId).toBe("req-1");
+    expect(store.getByCardMessageId("nonexistent")).toBeUndefined();
+  });
+
+  it("removes a pending request by requestId", () => {
+    store.add("req-1", "sess-1", "/workspace", "chat-1", "question");
+
+    expect(store.remove("req-1")).toBe(true);
+    expect(store.get("req-1")).toBeUndefined();
+    expect(store.size()).toBe(0);
+    expect(store.remove("req-1")).toBe(false);
+  });
+
+  it("removes all pending requests for a session", () => {
+    store.add("req-1", "sess-1", "/workspace", "chat-1", "question");
+    store.add("req-2", "sess-1", "/workspace", "chat-1", "permission");
+    store.add("req-3", "sess-2", "/workspace", "chat-2", "question");
+
+    expect(store.removeBySessionId("sess-1")).toBe(2);
+    expect(store.size()).toBe(1);
+    expect(store.has("req-3")).toBe(true);
+    expect(store.removeBySessionId("sess-1")).toBe(0);
+  });
+
+  it("reports correct has/size/getAll state", () => {
+    expect(store.has("req-1")).toBe(false);
+    expect(store.size()).toBe(0);
+    expect(store.getAll()).toEqual([]);
+
+    store.add("req-1", "sess-1", "/workspace", "chat-1", "question");
+    store.add("req-2", "sess-1", "/workspace", "chat-1", "permission");
+
+    expect(store.has("req-1")).toBe(true);
+    expect(store.size()).toBe(2);
+    expect(store.getAll()).toHaveLength(2);
+  });
+
+  it("clears all entries", () => {
+    store.add("req-1", "sess-1", "/workspace", "chat-1", "question");
+    store.add("req-2", "sess-2", "/workspace", "chat-2", "permission");
+
+    store.clear();
+    expect(store.size()).toBe(0);
+    expect(store.getAll()).toEqual([]);
+  });
+});

--- a/tests/unit/permission-card-callback.test.ts
+++ b/tests/unit/permission-card-callback.test.ts
@@ -44,7 +44,11 @@ function createHandler() {
   return { handler, permissionManager, openCodeClient, logger };
 }
 
-function buildCardAction(reply: string, requestId: string = "perm-1", openMessageId: string = "card-msg-1") {
+function buildCardAction(
+  reply: string,
+  requestId: string = "perm-1",
+  openMessageId: string = "card-msg-1",
+) {
   return {
     open_message_id: openMessageId,
     action: {
@@ -91,15 +95,16 @@ describe("PermissionCardHandler card action callbacks", () => {
     });
   });
 
-  it("removes the permission from the manager after resolution", async () => {
+  it("keeps the permission active after card reply (cleared by server event)", async () => {
     const { handler, permissionManager } = createHandler();
     permissionManager.startPermission(REQUEST, "card-msg-1");
     expect(permissionManager.isActiveMessage("card-msg-1")).toBe(true);
 
     await handler.handleCardAction(buildCardAction("approve"));
 
-    expect(permissionManager.isActiveMessage("card-msg-1")).toBe(false);
-    expect(permissionManager.getRequest("card-msg-1")).toBeNull();
+    // State is no longer cleared optimistically; server event clears it
+    expect(permissionManager.isActiveMessage("card-msg-1")).toBe(true);
+    expect(permissionManager.getRequest("card-msg-1")).not.toBeNull();
   });
 
   it("makes exactly ONE downstream reply call per action", async () => {
@@ -118,7 +123,11 @@ describe("PermissionCardHandler card action callbacks", () => {
     const event = {
       open_message_id: "card-msg-1",
       action: {
-        value: { action: "question_answer", reply: "approve", requestId: "perm-1" },
+        value: {
+          action: "question_answer",
+          reply: "approve",
+          requestId: "perm-1",
+        },
       },
     };
     await handler.handleCardAction(event);
@@ -133,7 +142,11 @@ describe("PermissionCardHandler card action callbacks", () => {
 
     const event = {
       action: {
-        value: { action: "permission_reply", reply: "approve", requestId: "perm-1" },
+        value: {
+          action: "permission_reply",
+          reply: "approve",
+          requestId: "perm-1",
+        },
       },
     };
     await handler.handleCardAction(event);

--- a/tests/unit/permission-card-duplicate.test.ts
+++ b/tests/unit/permission-card-duplicate.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { PermissionCardHandler } from "../../src/feishu/handlers/permission.js";
-import type { OpenCodePermissionClient } from "../../src/feishu/handlers/permission.js";
+import {
+  type OpenCodePermissionClient,
+  PermissionCardHandler,
+} from "../../src/feishu/handlers/permission.js";
 import { PermissionManager } from "../../src/permission/manager.js";
 import type { PermissionRequest } from "../../src/permission/types.js";
 
@@ -44,7 +46,11 @@ function createHandler() {
   return { handler, permissionManager, openCodeClient, logger };
 }
 
-function buildCardAction(reply: string, requestId: string = "perm-1", openMessageId: string = "card-msg-1") {
+function buildCardAction(
+  reply: string,
+  requestId: string = "perm-1",
+  openMessageId: string = "card-msg-1",
+) {
   return {
     open_message_id: openMessageId,
     action: {
@@ -62,7 +68,7 @@ describe("PermissionCardHandler duplicate rejection", () => {
 
     await handler.handleCardAction(action);
     expect(openCodeClient.permission.reply).toHaveBeenCalledTimes(1);
-    expect(permissionManager.isActiveMessage("card-msg-1")).toBe(false);
+    expect(permissionManager.isActiveMessage("card-msg-1")).toBe(true);
 
     await handler.handleCardAction(action);
     expect(openCodeClient.permission.reply).toHaveBeenCalledTimes(1);
@@ -80,9 +86,9 @@ describe("PermissionCardHandler duplicate rejection", () => {
     await handler.handleCardAction(action);
     const snapshotAfterSecond = permissionManager.getPendingCount();
 
-    expect(snapshotAfterFirst).toBe(0);
-    expect(snapshotAfterSecond).toBe(0);
-    expect(permissionManager.isActiveMessage("card-msg-1")).toBe(false);
+    expect(snapshotAfterFirst).toBe(1);
+    expect(snapshotAfterSecond).toBe(1);
+    expect(permissionManager.isActiveMessage("card-msg-1")).toBe(true);
   });
 
   it("unknown messageId is safely ignored", async () => {
@@ -119,7 +125,11 @@ describe("PermissionCardHandler duplicate rejection", () => {
     const event = {
       open_message_id: null,
       action: {
-        value: { action: "permission_reply", reply: "approve", requestId: "perm-1" },
+        value: {
+          action: "permission_reply",
+          reply: "approve",
+          requestId: "perm-1",
+        },
       },
     };
     const result = await handler.handleCardAction(event);

--- a/tests/unit/question-card-callback.test.ts
+++ b/tests/unit/question-card-callback.test.ts
@@ -109,7 +109,7 @@ describe("QuestionCardHandler - handleCardAction", () => {
     });
   });
 
-  it("clears question state after answering the last question", async () => {
+  it("keeps question state active after reply (cleared by server event)", async () => {
     const manager = new QuestionManager();
     const renderer = createMockRenderer();
     const client = createMockOpenCodeClient();
@@ -127,7 +127,8 @@ describe("QuestionCardHandler - handleCardAction", () => {
       }),
     );
 
-    expect(manager.isActive()).toBe(false);
+    expect(client.question.reply).toHaveBeenCalledTimes(1);
+    expect(manager.isActive()).toBe(true);
   });
 
   it("batches answers across multiple questions and replies once at the end", async () => {
@@ -177,7 +178,8 @@ describe("QuestionCardHandler - handleCardAction", () => {
       requestID: "req-multi",
       answers: [["Vue"], ["TypeScript"]],
     });
-    expect(manager.isActive()).toBe(false);
+    // State is no longer cleared optimistically; server event clears it
+    expect(manager.isActive()).toBe(true);
   });
 
   it("waits for an explicit submit action before replying to a multi-select question", async () => {
@@ -291,6 +293,7 @@ describe("QuestionCardHandler - handleCardAction", () => {
       requestID: "req-custom",
       answers: [["my custom answer"]],
     });
-    expect(manager.isActive()).toBe(false);
+    // State is no longer cleared optimistically; server event clears it
+    expect(manager.isActive()).toBe(true);
   });
 });

--- a/tests/unit/question-card-callback.test.ts
+++ b/tests/unit/question-card-callback.test.ts
@@ -225,6 +225,45 @@ describe("QuestionCardHandler - handleCardAction", () => {
     });
   });
 
+  it("ignores duplicate question submit callbacks while the first reply is still in flight", async () => {
+    const manager = new QuestionManager();
+    const renderer = createMockRenderer();
+    let resolveReply: (() => void) | undefined;
+    const client = {
+      question: {
+        reply: vi.fn().mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              resolveReply = () => resolve({ data: { success: true } });
+            }),
+        ),
+      },
+    };
+
+    manager.startQuestions([QUESTION], "req-duplicate");
+    manager.setActiveMessageId("msg-active-duplicate");
+
+    const handler = createHandler(manager, renderer, client);
+    const action = buildCardAction({
+      requestId: "req-duplicate",
+      messageId: "msg-active-duplicate",
+      optionIndex: 0,
+    });
+
+    const firstReply = handler.handleCardAction(action);
+    const duplicateReply = handler.handleCardAction(action);
+    await Promise.resolve();
+
+    expect(client.question.reply).toHaveBeenCalledTimes(1);
+
+    resolveReply?.();
+    await firstReply;
+    await duplicateReply;
+
+    expect(client.question.reply).toHaveBeenCalledTimes(1);
+    expect(manager.isActive()).toBe(true);
+  });
+
   it("returns an empty object for non-question card actions", async () => {
     const manager = new QuestionManager();
     const renderer = createMockRenderer();

--- a/tests/unit/response-pipeline.test.ts
+++ b/tests/unit/response-pipeline.test.ts
@@ -410,6 +410,55 @@ describe("ResponsePipelineController", () => {
     expect(harness.statusStore.get(context.sessionId)).toBe(state);
   });
 
+  it("finalizes active sessions in the failed directory when the supervisor reports a fatal subscription error", async () => {
+    const harness = createHarness();
+    const firstContext = makeTurnContext("session-1");
+    const secondContext = {
+      ...makeTurnContext("session-2"),
+      directory: firstContext.directory,
+    };
+    const thirdContext = makeTurnContext("session-3");
+
+    harness.controller.startTurn(firstContext);
+    harness.controller.startTurn(secondContext);
+    harness.controller.startTurn(thirdContext);
+
+    harness.controller.handleEventSupervisorFailure(
+      firstContext.directory,
+      new Error("fatal subscription failure"),
+    );
+
+    await drainSession(harness.controller, firstContext.sessionId);
+    await drainSession(harness.controller, secondContext.sessionId);
+    await drainSession(harness.controller, thirdContext.sessionId);
+
+    expect(harness.renderer.renderCompleteCard).toHaveBeenCalledTimes(2);
+    expect(harness.renderer.renderCompleteCard).toHaveBeenNthCalledWith(
+      1,
+      firstContext.receiveId,
+      "OpenCode error",
+      "OpenCode stream ended before a final reply was delivered.",
+      expect.objectContaining({ template: "red" }),
+    );
+    expect(harness.renderer.renderCompleteCard).toHaveBeenNthCalledWith(
+      2,
+      secondContext.receiveId,
+      "OpenCode error",
+      "OpenCode stream ended before a final reply was delivered.",
+      expect.objectContaining({ template: "red" }),
+    );
+    expect(harness.interactionManager.clearBusy).toHaveBeenCalledTimes(2);
+    expect(harness.interactionManager.clearBusy).toHaveBeenCalledWith(
+      firstContext.receiveId,
+    );
+    expect(harness.interactionManager.clearBusy).toHaveBeenCalledWith(
+      secondContext.receiveId,
+    );
+    expect(harness.statusStore.get(firstContext.sessionId)).toBeUndefined();
+    expect(harness.statusStore.get(secondContext.sessionId)).toBeUndefined();
+    expect(harness.statusStore.get(thirdContext.sessionId)).toBeDefined();
+  });
+
   it("uses the latest completed assistant message when the session goes idle", async () => {
     const harness = createHarness();
     const context = makeTurnContext();

--- a/tests/unit/runtime-summary-aggregator.test.ts
+++ b/tests/unit/runtime-summary-aggregator.test.ts
@@ -1,3 +1,4 @@
+import type { Event } from "@opencode-ai/sdk/v2";
 import { describe, expect, it, vi } from "vitest";
 import { RuntimeSummaryAggregator } from "../../src/app/runtime-summary-aggregator.js";
 import { FileStore } from "../../src/feishu/file-store.js";
@@ -7,20 +8,29 @@ import { PendingInteractionStore } from "../../src/pending/store.js";
 import { PermissionManager } from "../../src/permission/manager.js";
 import { QuestionManager } from "../../src/question/manager.js";
 
+function makeEvent(type: string, properties: Record<string, unknown>): Event {
+  return {
+    type,
+    properties,
+  } as unknown as Event;
+}
+
 function createRuntimeSummaryAggregator() {
   const interactionManager = new InteractionManager();
   const questionManager = new QuestionManager();
   const permissionManager = new PermissionManager();
+  const pendingStore = new PendingInteractionStore();
+  const statusStore = new StatusStore();
   const onQuestionEvent = vi.fn().mockResolvedValue(undefined);
   const onPermissionEvent = vi.fn().mockResolvedValue(undefined);
   const onEgressFile = vi.fn().mockResolvedValue(undefined);
 
   const aggregator = new RuntimeSummaryAggregator({
-    statusStore: new StatusStore(),
+    statusStore,
     questionManager,
     permissionManager,
     interactionManager,
-    pendingStore: new PendingInteractionStore(),
+    pendingStore,
     questionCardHandler: {
       handleQuestionEvent: onQuestionEvent,
     },
@@ -36,6 +46,10 @@ function createRuntimeSummaryAggregator() {
   return {
     aggregator,
     interactionManager,
+    pendingStore,
+    permissionManager,
+    questionManager,
+    statusStore,
   };
 }
 
@@ -72,5 +86,101 @@ describe("RuntimeSummaryAggregator", () => {
     aggregator.setSession("session-B");
 
     expect(onCleared).toHaveBeenCalledTimes(2);
+  });
+
+  it("question reply only clears the active request and uses pending chat mapping", () => {
+    const {
+      aggregator,
+      interactionManager,
+      pendingStore,
+      questionManager,
+      statusStore,
+    } = createRuntimeSummaryAggregator();
+
+    aggregator.setCallbacks({});
+    aggregator.setSession("session-stale");
+    questionManager.startQuestions(
+      [
+        {
+          question: "Pick one",
+          header: "Pick one",
+          options: [{ label: "yes", description: "continue" }],
+          multiple: false,
+          custom: false,
+        },
+      ],
+      "req-active",
+    );
+    interactionManager.start("chat-stale", {
+      kind: "question",
+      expectedInput: "callback",
+      expiresInMs: null,
+    });
+    pendingStore.add(
+      "req-stale",
+      "session-stale",
+      "/workspace/a",
+      "chat-stale",
+      "question",
+    );
+    statusStore.startTurn({
+      sessionId: "session-other",
+      directory: "/workspace/b",
+      receiveId: "chat-other",
+      sourceMessageId: "msg-1",
+    });
+
+    aggregator.processEvent(
+      makeEvent("question.replied", {
+        sessionID: "session-stale",
+        requestID: "req-stale",
+      }),
+    );
+
+    expect(questionManager.getRequestID()).toBe("req-active");
+    expect(interactionManager.isActive("chat-stale")).toBe(false);
+    expect(pendingStore.has("req-stale")).toBe(false);
+  });
+
+  it("permission reply clears the pending chat even without status store entry", () => {
+    const { aggregator, interactionManager, pendingStore, permissionManager } =
+      createRuntimeSummaryAggregator();
+
+    aggregator.setCallbacks({});
+    aggregator.setSession("session-stale");
+    permissionManager.startPermission(
+      {
+        id: "perm-1",
+        sessionID: "session-stale",
+        permission: "bash",
+        patterns: [],
+        metadata: {},
+        always: [],
+      },
+      "msg-perm",
+    );
+    interactionManager.start("chat-perm", {
+      kind: "permission",
+      expectedInput: "callback",
+      expiresInMs: null,
+    });
+    pendingStore.add(
+      "perm-1",
+      "session-stale",
+      "/workspace/a",
+      "chat-perm",
+      "permission",
+    );
+
+    aggregator.processEvent(
+      makeEvent("permission.replied", {
+        sessionID: "session-stale",
+        requestID: "perm-1",
+      }),
+    );
+
+    expect(interactionManager.isActive("chat-perm")).toBe(false);
+    expect(pendingStore.has("perm-1")).toBe(false);
+    expect(permissionManager.getRequest("msg-perm")).toBeNull();
   });
 });

--- a/tests/unit/runtime-summary-aggregator.test.ts
+++ b/tests/unit/runtime-summary-aggregator.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { RuntimeSummaryAggregator } from "../../src/app/runtime-summary-aggregator.js";
+import { FileStore } from "../../src/feishu/file-store.js";
+import { StatusStore } from "../../src/feishu/status-store.js";
+import { InteractionManager } from "../../src/interaction/manager.js";
+import { PendingInteractionStore } from "../../src/pending/store.js";
+import { PermissionManager } from "../../src/permission/manager.js";
+import { QuestionManager } from "../../src/question/manager.js";
+
+function createRuntimeSummaryAggregator() {
+  const interactionManager = new InteractionManager();
+  const questionManager = new QuestionManager();
+  const permissionManager = new PermissionManager();
+  const onQuestionEvent = vi.fn().mockResolvedValue(undefined);
+  const onPermissionEvent = vi.fn().mockResolvedValue(undefined);
+  const onEgressFile = vi.fn().mockResolvedValue(undefined);
+
+  const aggregator = new RuntimeSummaryAggregator({
+    statusStore: new StatusStore(),
+    questionManager,
+    permissionManager,
+    interactionManager,
+    pendingStore: new PendingInteractionStore(),
+    questionCardHandler: {
+      handleQuestionEvent: onQuestionEvent,
+    },
+    permissionCardHandler: {
+      handlePermissionEvent: onPermissionEvent,
+    },
+    fileHandler: {
+      egressFile: onEgressFile,
+    },
+    fileStore: new FileStore(),
+  });
+
+  return {
+    aggregator,
+    interactionManager,
+  };
+}
+
+describe("RuntimeSummaryAggregator", () => {
+  it("session switch does not clear unrelated chat interaction state", () => {
+    const { aggregator, interactionManager } = createRuntimeSummaryAggregator();
+
+    aggregator.setCallbacks({});
+    aggregator.setSession("session-A");
+
+    interactionManager.start("chat-A", {
+      kind: "question",
+      expectedInput: "text",
+      expiresInMs: null,
+    });
+    interactionManager.start("chat-B", {
+      kind: "permission",
+      expectedInput: "callback",
+      expiresInMs: null,
+    });
+
+    aggregator.setSession("session-B");
+
+    expect(interactionManager.isActive("chat-A")).toBe(true);
+    expect(interactionManager.isActive("chat-B")).toBe(true);
+  });
+
+  it("onCleared callback is still invoked on session switch", () => {
+    const { aggregator } = createRuntimeSummaryAggregator();
+    const onCleared = vi.fn();
+
+    aggregator.setCallbacks({ onCleared });
+    aggregator.setSession("session-A");
+    aggregator.setSession("session-B");
+
+    expect(onCleared).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/summary-aggregator.test.ts
+++ b/tests/unit/summary-aggregator.test.ts
@@ -539,6 +539,162 @@ describe("SummaryAggregator", () => {
     expect(onSessionError).toHaveBeenCalledWith("session-1", "failure");
   });
 
+  it("emits question.replied callback with sessionId and requestId", () => {
+    const onQuestionReplied = vi.fn();
+    aggregator.setOnQuestionReplied(onQuestionReplied);
+    aggregator.setSession("session-1");
+
+    aggregator.processEvent(
+      makeEvent("question.replied", {
+        sessionID: "session-1",
+        requestID: "req-q-1",
+        answers: [["Yes"]],
+      }),
+    );
+
+    expect(onQuestionReplied).toHaveBeenCalledOnce();
+    expect(onQuestionReplied).toHaveBeenCalledWith("session-1", "req-q-1");
+  });
+
+  it("emits question.rejected callback with sessionId and requestId", () => {
+    const onQuestionRejected = vi.fn();
+    aggregator.setOnQuestionRejected(onQuestionRejected);
+    aggregator.setSession("session-1");
+
+    aggregator.processEvent(
+      makeEvent("question.rejected", {
+        sessionID: "session-1",
+        requestID: "req-q-2",
+      }),
+    );
+
+    expect(onQuestionRejected).toHaveBeenCalledOnce();
+    expect(onQuestionRejected).toHaveBeenCalledWith("session-1", "req-q-2");
+  });
+
+  it("emits permission.replied callback with sessionId and requestId", () => {
+    const onPermissionReplied = vi.fn();
+    aggregator.setOnPermissionReplied(onPermissionReplied);
+    aggregator.setSession("session-1");
+
+    aggregator.processEvent(
+      makeEvent("permission.replied", {
+        sessionID: "session-1",
+        requestID: "req-p-1",
+        reply: "once",
+      }),
+    );
+
+    expect(onPermissionReplied).toHaveBeenCalledOnce();
+    expect(onPermissionReplied).toHaveBeenCalledWith("session-1", "req-p-1");
+  });
+
+  it("falls back to id when requestID is missing on replied/rejected events", () => {
+    const onQuestionReplied = vi.fn();
+    const onQuestionRejected = vi.fn();
+    const onPermissionReplied = vi.fn();
+    aggregator.setOnQuestionReplied(onQuestionReplied);
+    aggregator.setOnQuestionRejected(onQuestionRejected);
+    aggregator.setOnPermissionReplied(onPermissionReplied);
+    aggregator.setSession("session-1");
+
+    aggregator.processEvent(
+      makeEvent("question.replied", {
+        sessionID: "session-1",
+        id: "fallback-q-1",
+        answers: [["A"]],
+      }),
+    );
+    aggregator.processEvent(
+      makeEvent("question.rejected", {
+        sessionID: "session-1",
+        id: "fallback-q-2",
+      }),
+    );
+    aggregator.processEvent(
+      makeEvent("permission.replied", {
+        sessionID: "session-1",
+        id: "fallback-p-1",
+        reply: "always",
+      }),
+    );
+
+    expect(onQuestionReplied).toHaveBeenCalledWith("session-1", "fallback-q-1");
+    expect(onQuestionRejected).toHaveBeenCalledWith(
+      "session-1",
+      "fallback-q-2",
+    );
+    expect(onPermissionReplied).toHaveBeenCalledWith(
+      "session-1",
+      "fallback-p-1",
+    );
+  });
+
+  it("ignores replied/rejected events for foreign sessions", () => {
+    const onQuestionReplied = vi.fn();
+    const onQuestionRejected = vi.fn();
+    const onPermissionReplied = vi.fn();
+    aggregator.setOnQuestionReplied(onQuestionReplied);
+    aggregator.setOnQuestionRejected(onQuestionRejected);
+    aggregator.setOnPermissionReplied(onPermissionReplied);
+    aggregator.setSession("session-1");
+
+    aggregator.processEvent(
+      makeEvent("question.replied", {
+        sessionID: "session-other",
+        requestID: "req-1",
+        answers: [["X"]],
+      }),
+    );
+    aggregator.processEvent(
+      makeEvent("question.rejected", {
+        sessionID: "session-other",
+        requestID: "req-2",
+      }),
+    );
+    aggregator.processEvent(
+      makeEvent("permission.replied", {
+        sessionID: "session-other",
+        requestID: "req-3",
+        reply: "reject",
+      }),
+    );
+
+    expect(onQuestionReplied).not.toHaveBeenCalled();
+    expect(onQuestionRejected).not.toHaveBeenCalled();
+    expect(onPermissionReplied).not.toHaveBeenCalled();
+  });
+
+  it("ignores replied/rejected events missing required fields", () => {
+    const onQuestionReplied = vi.fn();
+    const onQuestionRejected = vi.fn();
+    const onPermissionReplied = vi.fn();
+    aggregator.setOnQuestionReplied(onQuestionReplied);
+    aggregator.setOnQuestionRejected(onQuestionRejected);
+    aggregator.setOnPermissionReplied(onPermissionReplied);
+    aggregator.setSession("session-1");
+
+    // Missing sessionID
+    aggregator.processEvent(
+      makeEvent("question.replied", { requestID: "req-1", answers: [["X"]] }),
+    );
+    // Missing both requestID and id
+    aggregator.processEvent(
+      makeEvent("question.rejected", { sessionID: "session-1" }),
+    );
+    // Missing sessionID
+    aggregator.processEvent(
+      makeEvent("permission.replied", {
+        requestID: "req-3",
+        reply: "once",
+      }),
+    );
+
+    expect(onQuestionReplied).not.toHaveBeenCalled();
+    expect(onQuestionRejected).not.toHaveBeenCalled();
+    expect(onPermissionReplied).not.toHaveBeenCalled();
+  });
+
   it("fires question error callback when question tool fails", () => {
     const onQuestionError = vi.fn();
     aggregator.setOnQuestionError(onQuestionError);


### PR DESCRIPTION
## Summary

Implements all 5 phases of the orchestration subsystem refactor to align the bridge's question/permission handling with the OpenCode browser app's pending-interaction model.

- **Phase 1**: Fix event-subscription readiness race; add server-event handlers for `question.replied`, `question.rejected`, `permission.replied`; add 6 regression tests
- **Phase 2**: Introduce `PendingInteractionStore` — request-centric pending store keyed by `requestID`; 10 unit tests
- **Phase 3**: Move clearing logic from optimistic (after API reply) to server-confirmed events; add duplicate-click guard via `repliedRequestIds` in `PermissionManager`
- **Phase 4**: Introduce `EventSupervisor` — long-lived event subscription surviving turn lifecycle, with bootstrap from `question.list()`/`permission.list()`; 12 unit tests
- **Phase 5**: Remove `interactionManager.clearAll()` blast on session switch; remove global singleton exports from all 5 manager modules; add `eventSupervisor.stop()` to shutdown; 2 unit tests

## Key architectural changes

1. **Pending interactions are now request-centric** — keyed by `requestID`, not message ID
2. **Event subscription is long-lived** — `EventSupervisor` manages durable subscriptions independent of turn lifecycle
3. **State clearing is server-authoritative** — UI is cleared only on `question.replied`/`rejected` and `permission.replied` events, not optimistically after API calls
4. **Session switch is scoped** — switching sessions no longer blasts all chat interaction states
5. **No global singletons** — managers are instantiated in `start-feishu-app.ts` and injected via DI

## Test results

64 test files, 423 tests, all passing. Lint clean. Build clean.

Closes #38