### PR TITLE
feat(feishu): update cards to resolved/cancelled state after user interaction

### DIFF
--- a/src/app/runtime-event-handlers.ts
+++ b/src/app/runtime-event-handlers.ts
@@ -178,6 +178,18 @@ export function createRuntimeEventHandlers(
   const messageTasks = new Map<string, Promise<void>>();
   const cardActionTasks = new Map<string, Promise<void>>();
 
+  const mergeCardActionResponses = (
+    ...responses: CardActionResponse[]
+  ): CardActionResponse => {
+    for (const response of responses) {
+      if (response.toast) {
+        return response;
+      }
+    }
+
+    return {};
+  };
+
   const sendBusyFeedback = async (receiveId: string): Promise<void> => {
     if (!options.renderer) {
       return;
@@ -557,9 +569,17 @@ export function createRuntimeEventHandlers(
       const queueKey = getCardActionQueueKey(event);
       let response: CardActionResponse = {};
       await enqueueCardActionTask(queueKey, async () => {
-        await options.questionCardHandler.handleCardAction(event);
-        await options.permissionCardHandler.handleCardAction(event);
-        response = await options.controlRouter.handleCardAction(event);
+        const questionResponse =
+          await options.questionCardHandler.handleCardAction(event);
+        const permissionResponse =
+          await options.permissionCardHandler.handleCardAction(event);
+        const controlResponse =
+          await options.controlRouter.handleCardAction(event);
+        response = mergeCardActionResponses(
+          controlResponse,
+          permissionResponse,
+          questionResponse,
+        );
       });
       return response;
     },

--- a/src/feishu/cards.ts
+++ b/src/feishu/cards.ts
@@ -590,6 +590,62 @@ export function buildConfirmCard(data: ConfirmCardData): InteractiveCard {
   };
 }
 
+export function buildResolvedCard(
+  title: string,
+  selectedValue: string,
+): InteractiveCard {
+  return {
+    header: {
+      title: plainText(title),
+      template: "green",
+    },
+    elements: [
+      {
+        tag: "markdown",
+        content: `✅ **${selectedValue}**`,
+      },
+    ],
+  };
+}
+
+export function buildCancelledCard(title: string): InteractiveCard {
+  return {
+    header: {
+      title: plainText(title),
+      template: "grey",
+    },
+    elements: [
+      {
+        tag: "markdown",
+        content: "Cancelled",
+      },
+    ],
+  };
+}
+
+export function buildResolvedQuestionCard(
+  questionText: string,
+  selectedAnswers: string[],
+): InteractiveCard {
+  const answerList =
+    selectedAnswers.length > 0
+      ? selectedAnswers.map((answer) => `• ${answer}`).join("\n")
+      : "No selection";
+
+  return {
+    header: {
+      title: plainText("Input Required"),
+      template: "green",
+    },
+    elements: [
+      {
+        tag: "markdown",
+        content: `${questionText}\n\n✅ **Answered:** \n${answerList}`,
+      },
+    ],
+  };
+}
+
 export function buildControlCard(
   status: string,
   options: { showCancel?: boolean } = {},

--- a/src/feishu/control-router.ts
+++ b/src/feishu/control-router.ts
@@ -343,9 +343,13 @@ function getCardActionOpenMessageId(
   event: Record<string, unknown>,
 ): string | null {
   const payload = getCardActionPayload(event);
+  const context = isRecord(payload.context) ? payload.context : null;
+
   return typeof payload.open_message_id === "string"
     ? payload.open_message_id
-    : null;
+    : typeof context?.open_message_id === "string"
+      ? context.open_message_id
+      : null;
 }
 
 function buildCardActionToast(
@@ -519,11 +523,9 @@ export class ControlRouter {
             getCardActionReceiveId(event),
             sessionId,
           );
-          await this.updateActionCard(
-            event,
-            "Session Picker",
-            result.success ? sessionId : null,
-          );
+          if (result.success) {
+            await this.updateActionCard(event, "Session Picker", sessionId);
+          }
           return buildCardActionToast(
             result.message,
             result.success ? "success" : "error",
@@ -540,11 +542,9 @@ export class ControlRouter {
             getCardActionReceiveId(event),
             modelName,
           );
-          await this.updateActionCard(
-            event,
-            "Model Picker",
-            result.success ? modelName : null,
-          );
+          if (result.success) {
+            await this.updateActionCard(event, "Model Picker", modelName);
+          }
           return buildCardActionToast(
             result.message,
             result.success ? "success" : "error",
@@ -561,11 +561,9 @@ export class ControlRouter {
             getCardActionReceiveId(event),
             agentName,
           );
-          await this.updateActionCard(
-            event,
-            "Agent Picker",
-            result.success ? agentName : null,
-          );
+          if (result.success) {
+            await this.updateActionCard(event, "Agent Picker", agentName);
+          }
           return buildCardActionToast(
             result.message,
             result.success ? "success" : "error",
@@ -582,11 +580,9 @@ export class ControlRouter {
             getCardActionReceiveId(event),
             projectId,
           );
-          await this.updateActionCard(
-            event,
-            "Projects",
-            result.success ? projectId : null,
-          );
+          if (result.success) {
+            await this.updateActionCard(event, "Projects", projectId);
+          }
           return buildCardActionToast(
             result.message,
             result.success ? "success" : "error",
@@ -602,11 +598,9 @@ export class ControlRouter {
             getCardActionReceiveId(event),
             directory,
           );
-          await this.updateActionCard(
-            event,
-            "Projects",
-            result.success ? directory : null,
-          );
+          if (result.success) {
+            await this.updateActionCard(event, "Projects", directory);
+          }
           return buildCardActionToast(
             result.message,
             result.success ? "success" : "error",
@@ -617,7 +611,7 @@ export class ControlRouter {
           if (receiveId) {
             this.interactionManager.clearBusy(receiveId);
           }
-          await this.updateActionCard(event, "Control", null);
+          await this.updateCancelledActionCard(event, "Control");
           return buildCardActionToast("Operation cancelled", "info");
         }
         case "confirm_write": {
@@ -640,11 +634,13 @@ export class ControlRouter {
 
           try {
             const result = await this.executeCreateSession(receiveId);
-            await this.updateActionCard(
-              event,
-              "⚠️ Confirmation Required",
-              result.success ? "Session created" : null,
-            );
+            if (result.success) {
+              await this.updateActionCard(
+                event,
+                "⚠️ Confirmation Required",
+                "Session created",
+              );
+            }
             if (receiveId && result.message) {
               await this.renderer.sendText(receiveId, result.message);
             }
@@ -657,11 +653,6 @@ export class ControlRouter {
             this.logger.error(
               "[ControlRouter] Failed to create session from card action",
               error,
-            );
-            await this.updateActionCard(
-              event,
-              "⚠️ Confirmation Required",
-              null,
             );
             if (receiveId) {
               try {
@@ -685,7 +676,10 @@ export class ControlRouter {
         }
         case "reject_write": {
           const receiveId = getCardActionReceiveId(event);
-          await this.updateActionCard(event, "⚠️ Confirmation Required", null);
+          await this.updateCancelledActionCard(
+            event,
+            "⚠️ Confirmation Required",
+          );
           if (receiveId) {
             await this.renderer.sendText(receiveId, "Operation cancelled");
           }
@@ -798,7 +792,7 @@ export class ControlRouter {
         }
       }
       case "selection_cancel":
-        await this.updateActionCard(event, "Selection", null);
+        await this.updateCancelledActionCard(event, "Selection");
         return buildCardActionToast("Cancelled", "info");
       case "selection_back":
       case "selection_page": {
@@ -2344,7 +2338,7 @@ export class ControlRouter {
   private async updateActionCard(
     event: Record<string, unknown>,
     title: string,
-    selectedValue: string | null,
+    selectedValue: string,
   ): Promise<void> {
     const messageId = getCardActionOpenMessageId(event);
     if (!messageId) {
@@ -2352,10 +2346,24 @@ export class ControlRouter {
     }
 
     try {
-      const card = selectedValue
-        ? buildResolvedCard(title, selectedValue)
-        : buildCancelledCard(title);
+      const card = buildResolvedCard(title, selectedValue);
       await this.renderer.updateCard(messageId, card);
+    } catch (error) {
+      this.logger.warn("[ControlRouter] Failed to update action card", error);
+    }
+  }
+
+  private async updateCancelledActionCard(
+    event: Record<string, unknown>,
+    title: string,
+  ): Promise<void> {
+    const messageId = getCardActionOpenMessageId(event);
+    if (!messageId) {
+      return;
+    }
+
+    try {
+      await this.renderer.updateCard(messageId, buildCancelledCard(title));
     } catch (error) {
       this.logger.warn("[ControlRouter] Failed to update action card", error);
     }

--- a/src/feishu/control-router.ts
+++ b/src/feishu/control-router.ts
@@ -12,7 +12,11 @@ import type {
 } from "../settings/manager.js";
 import type { Logger } from "../utils/logger.js";
 import { APP_VERSION } from "../version.js";
-import { buildConfirmCard } from "./cards.js";
+import {
+  buildCancelledCard,
+  buildConfirmCard,
+  buildResolvedCard,
+} from "./cards.js";
 import type { FeishuClients } from "./client.js";
 import type {
   ProjectPickerEntry,
@@ -229,7 +233,7 @@ export type ControlRouterSessionStore = Pick<
 
 export type ControlRouterRenderer = Pick<
   FeishuRenderer,
-  "sendCard" | "sendText" | "updateCompleteCard"
+  "sendCard" | "sendText" | "updateCompleteCard" | "updateCard"
 >;
 
 export type ControlRouterInteractionStore = Pick<
@@ -333,6 +337,15 @@ function getCardActionReceiveId(event: Record<string, unknown>): string {
     : typeof context?.open_chat_id === "string"
       ? context.open_chat_id
       : "";
+}
+
+function getCardActionOpenMessageId(
+  event: Record<string, unknown>,
+): string | null {
+  const payload = getCardActionPayload(event);
+  return typeof payload.open_message_id === "string"
+    ? payload.open_message_id
+    : null;
 }
 
 function buildCardActionToast(
@@ -506,6 +519,11 @@ export class ControlRouter {
             getCardActionReceiveId(event),
             sessionId,
           );
+          await this.updateActionCard(
+            event,
+            "Session Picker",
+            result.success ? sessionId : null,
+          );
           return buildCardActionToast(
             result.message,
             result.success ? "success" : "error",
@@ -521,6 +539,11 @@ export class ControlRouter {
           const result = await this.handleModel(
             getCardActionReceiveId(event),
             modelName,
+          );
+          await this.updateActionCard(
+            event,
+            "Model Picker",
+            result.success ? modelName : null,
           );
           return buildCardActionToast(
             result.message,
@@ -538,6 +561,11 @@ export class ControlRouter {
             getCardActionReceiveId(event),
             agentName,
           );
+          await this.updateActionCard(
+            event,
+            "Agent Picker",
+            result.success ? agentName : null,
+          );
           return buildCardActionToast(
             result.message,
             result.success ? "success" : "error",
@@ -554,6 +582,11 @@ export class ControlRouter {
             getCardActionReceiveId(event),
             projectId,
           );
+          await this.updateActionCard(
+            event,
+            "Projects",
+            result.success ? projectId : null,
+          );
           return buildCardActionToast(
             result.message,
             result.success ? "success" : "error",
@@ -569,19 +602,24 @@ export class ControlRouter {
             getCardActionReceiveId(event),
             directory,
           );
+          await this.updateActionCard(
+            event,
+            "Projects",
+            result.success ? directory : null,
+          );
           return buildCardActionToast(
             result.message,
             result.success ? "success" : "error",
           );
         }
-        case "control_cancel":
-          {
-            const receiveId = getCardActionReceiveId(event);
-            if (receiveId) {
-              this.interactionManager.clearBusy(receiveId);
-            }
+        case "control_cancel": {
+          const receiveId = getCardActionReceiveId(event);
+          if (receiveId) {
+            this.interactionManager.clearBusy(receiveId);
           }
+          await this.updateActionCard(event, "Control", null);
           return buildCardActionToast("Operation cancelled", "info");
+        }
         case "confirm_write": {
           const operationId =
             typeof value?.operationId === "string" ? value.operationId : null;
@@ -602,6 +640,11 @@ export class ControlRouter {
 
           try {
             const result = await this.executeCreateSession(receiveId);
+            await this.updateActionCard(
+              event,
+              "⚠️ Confirmation Required",
+              result.success ? "Session created" : null,
+            );
             if (receiveId && result.message) {
               await this.renderer.sendText(receiveId, result.message);
             }
@@ -614,6 +657,11 @@ export class ControlRouter {
             this.logger.error(
               "[ControlRouter] Failed to create session from card action",
               error,
+            );
+            await this.updateActionCard(
+              event,
+              "⚠️ Confirmation Required",
+              null,
             );
             if (receiveId) {
               try {
@@ -637,6 +685,7 @@ export class ControlRouter {
         }
         case "reject_write": {
           const receiveId = getCardActionReceiveId(event);
+          await this.updateActionCard(event, "⚠️ Confirmation Required", null);
           if (receiveId) {
             await this.renderer.sendText(receiveId, "Operation cancelled");
           }
@@ -700,6 +749,9 @@ export class ControlRouter {
                   })();
 
             const result = await this.handleModel(receiveId, fullModelName);
+            if (result.success) {
+              await this.updateActionCard(event, "Model Picker", fullModelName);
+            }
             return buildCardActionToast(
               result.message,
               result.success ? "success" : "error",
@@ -707,6 +759,13 @@ export class ControlRouter {
           }
           case "session": {
             const result = await this.handleSession(receiveId, action.value);
+            if (result.success) {
+              await this.updateActionCard(
+                event,
+                "Session Picker",
+                action.value,
+              );
+            }
             return buildCardActionToast(
               result.message,
               result.success ? "success" : "error",
@@ -716,6 +775,9 @@ export class ControlRouter {
             const result = isAbsolute(action.value)
               ? await this.discoverProject(receiveId, action.value)
               : await this.handleProjects(receiveId, action.value);
+            if (result.success) {
+              await this.updateActionCard(event, "Projects", action.value);
+            }
             return buildCardActionToast(
               result.message,
               result.success ? "success" : "error",
@@ -723,6 +785,9 @@ export class ControlRouter {
           }
           case "agent": {
             const result = await this.handleAgent(receiveId, action.value);
+            if (result.success) {
+              await this.updateActionCard(event, "Agent Picker", action.value);
+            }
             return buildCardActionToast(
               result.message,
               result.success ? "success" : "error",
@@ -733,6 +798,7 @@ export class ControlRouter {
         }
       }
       case "selection_cancel":
+        await this.updateActionCard(event, "Selection", null);
         return buildCardActionToast("Cancelled", "info");
       case "selection_back":
       case "selection_page": {
@@ -2272,6 +2338,26 @@ export class ControlRouter {
         `[ControlRouter] Failed to update aborted status card: session=${turnState.sessionId}, messageId=${turnState.statusCardMessageId}`,
         error,
       );
+    }
+  }
+
+  private async updateActionCard(
+    event: Record<string, unknown>,
+    title: string,
+    selectedValue: string | null,
+  ): Promise<void> {
+    const messageId = getCardActionOpenMessageId(event);
+    if (!messageId) {
+      return;
+    }
+
+    try {
+      const card = selectedValue
+        ? buildResolvedCard(title, selectedValue)
+        : buildCancelledCard(title);
+      await this.renderer.updateCard(messageId, card);
+    } catch (error) {
+      this.logger.warn("[ControlRouter] Failed to update action card", error);
     }
   }
 

--- a/src/feishu/handlers/question.ts
+++ b/src/feishu/handlers/question.ts
@@ -1,7 +1,9 @@
+import type { InteractiveCard } from "@larksuiteoapi/node-sdk";
 import type { Question } from "../../question/types.js";
 import type { QuestionManager } from "../../question/manager.js";
 import type { Logger } from "../../utils/logger.js";
 import { logger as defaultLogger } from "../../utils/logger.js";
+import { buildResolvedQuestionCard } from "../cards.js";
 
 export const QUESTION_GUIDED_REPLY_PREFIX = "answer:";
 
@@ -21,6 +23,7 @@ export interface QuestionRenderer {
     requestId: string,
   ): Promise<string | undefined>;
   sendText?(receiveId: string, text: string): Promise<string[]>;
+  updateCard?(messageId: string, card: InteractiveCard): Promise<void>;
 }
 
 export interface QuestionInteractionManager {
@@ -218,7 +221,7 @@ export class QuestionCardHandler {
 
   async handleCardAction(
     event: Record<string, unknown>,
-  ): Promise<Record<string, never>> {
+  ): Promise<{ toast?: { type: string; content: string } }> {
     const actionValue = extractActionValue(event);
     if (!actionValue) {
       return {};
@@ -256,10 +259,20 @@ export class QuestionCardHandler {
     const answerValues = this.questionManager.getAnswerValues(currentIndex);
 
     if (actionValue.action === "question_toggle") {
+      const selectedLabels =
+        this.questionManager.getSelectedAnswerLabels(currentIndex);
       this.logger.debug(
         `[QuestionCardHandler] Toggled selections for question ${currentIndex}: ${answerValues.join(", ")}`,
       );
-      return {};
+      return {
+        toast: {
+          type: "info",
+          content:
+            selectedLabels.length > 0
+              ? `Selected: ${selectedLabels.join(", ")}`
+              : "Selection cleared",
+        },
+      };
     }
 
     if (answerValues.length === 0) {
@@ -275,7 +288,12 @@ export class QuestionCardHandler {
 
     await this.advanceQuestionFlow();
 
-    return {};
+    return {
+      toast: {
+        type: "success",
+        content: `Answer submitted: ${answerValues.join(", ")}`,
+      },
+    };
   }
 
   private async advanceQuestionFlow(): Promise<void> {
@@ -351,8 +369,43 @@ export class QuestionCardHandler {
       `[QuestionCardHandler] Forwarded ${answers.length} answers for request ${requestID}`,
     );
 
+    await this.updateQuestionCardToResolved();
+
     this.activeReceiveId = null;
     this.activeSourceMessageId = null;
+  }
+
+  private async updateQuestionCardToResolved(): Promise<void> {
+    const activeMessageId = this.questionManager.getActiveMessageId();
+    if (!activeMessageId || !this.renderer.updateCard) {
+      return;
+    }
+
+    const currentIndex = this.questionManager.getCurrentIndex();
+    const question = this.questionManager.getCurrentQuestion();
+    const questionText = question?.question ?? "Question";
+    const answerLabels =
+      this.questionManager.getSelectedAnswerLabels(currentIndex);
+    const customAnswer = this.questionManager.getCustomAnswer(currentIndex);
+    const displayAnswers =
+      answerLabels.length > 0
+        ? answerLabels
+        : customAnswer
+          ? [customAnswer]
+          : [];
+
+    try {
+      const resolvedCard = buildResolvedQuestionCard(
+        questionText,
+        displayAnswers,
+      );
+      await this.renderer.updateCard(activeMessageId, resolvedCard);
+    } catch (error) {
+      this.logger.warn(
+        "[QuestionCardHandler] Failed to update question card to resolved state",
+        error,
+      );
+    }
   }
 
   private syncInteractionState(question: Question): void {

--- a/src/feishu/handlers/question.ts
+++ b/src/feishu/handlers/question.ts
@@ -4,6 +4,7 @@ import type { QuestionManager } from "../../question/manager.js";
 import type { Logger } from "../../utils/logger.js";
 import { logger as defaultLogger } from "../../utils/logger.js";
 import { buildResolvedQuestionCard } from "../cards.js";
+import type { CardActionResponse } from "../control-router.js";
 
 export const QUESTION_GUIDED_REPLY_PREFIX = "answer:";
 
@@ -63,10 +64,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function getCardActionPayload(
+  event: Record<string, unknown>,
+): Record<string, unknown> {
+  return isRecord(event.event) ? event.event : event;
+}
+
 function extractActionValue(
   event: Record<string, unknown>,
 ): CardActionValue | null {
-  const actionObj = event.action;
+  const payload = getCardActionPayload(event);
+  const actionObj = payload.action;
   if (!isRecord(actionObj)) {
     return null;
   }
@@ -107,9 +115,14 @@ function extractActionValue(
 }
 
 function extractOpenMessageId(event: Record<string, unknown>): string | null {
-  return typeof event.open_message_id === "string"
-    ? event.open_message_id
-    : null;
+  const payload = getCardActionPayload(event);
+  const context = isRecord(payload.context) ? payload.context : null;
+
+  return typeof payload.open_message_id === "string"
+    ? payload.open_message_id
+    : typeof context?.open_message_id === "string"
+      ? context.open_message_id
+      : null;
 }
 
 export class QuestionCardHandler {
@@ -221,7 +234,7 @@ export class QuestionCardHandler {
 
   async handleCardAction(
     event: Record<string, unknown>,
-  ): Promise<{ toast?: { type: string; content: string } }> {
+  ): Promise<CardActionResponse> {
     const actionValue = extractActionValue(event);
     if (!actionValue) {
       return {};

--- a/tests/unit/control-selection-cards.test.ts
+++ b/tests/unit/control-selection-cards.test.ts
@@ -602,6 +602,33 @@ describe("Selection card builders", () => {
     );
   });
 
+  it("updates cards when nested callbacks carry open_message_id in context", async () => {
+    const renderer = createMockRenderer();
+    const settings = createMockSettings();
+    const router = createRouter({ settingsManager: settings, renderer });
+
+    await router.handleCardAction({
+      event: {
+        action: {
+          value: { action: "select_model", modelName: "openai/gpt-4.1" },
+        },
+        context: {
+          open_chat_id: "chat-nested",
+          open_message_id: "msg-nested-card",
+        },
+      },
+    });
+
+    expect(renderer.updateCard).toHaveBeenCalledWith(
+      "msg-nested-card",
+      expect.objectContaining({
+        header: expect.objectContaining({
+          template: "green",
+        }),
+      }),
+    );
+  });
+
   it("handleCardAction returns toast feedback when callback has no chat id", async () => {
     const renderer = createMockRenderer();
     const router = createRouter({ renderer });
@@ -736,5 +763,31 @@ describe("Selection card builders", () => {
       }),
     ).resolves.toEqual({});
     expect(renderer.sendCard).toHaveBeenCalled();
+  });
+
+  it("leaves the original card in place when selection handling fails", async () => {
+    const renderer = createMockRenderer();
+    const openCodeClient = createMockOpenCodeClient();
+    openCodeClient.session.get.mockResolvedValue({
+      data: null,
+      error: { message: "not found" },
+    });
+    const router = createRouter({ renderer, openCodeClient });
+
+    const result = await router.handleCardAction({
+      open_chat_id: "chat-1",
+      open_message_id: "msg-failed-card",
+      action: {
+        value: { action: "select_session", sessionId: "sess-missing" },
+      },
+    });
+
+    expect(result).toEqual({
+      toast: {
+        type: "error",
+        content: "Failed to switch session",
+      },
+    });
+    expect(renderer.updateCard).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/question-card-callback.test.ts
+++ b/tests/unit/question-card-callback.test.ts
@@ -38,6 +38,7 @@ function createMockRenderer(): QuestionRenderer {
   return {
     renderQuestionCard: vi.fn().mockResolvedValue("msg-card-new"),
     sendText: vi.fn().mockResolvedValue(["msg-guidance-1"]),
+    updateCard: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -192,7 +193,7 @@ describe("QuestionCardHandler - handleCardAction", () => {
     const handler = createHandler(manager, renderer, client);
     await handler.handleQuestionEvent("chat-1", "source-msg-1");
 
-    await handler.handleCardAction(
+    const firstToggleResult = await handler.handleCardAction(
       buildCardAction({
         action: "question_toggle",
         requestId: "req-multi-select",
@@ -200,7 +201,7 @@ describe("QuestionCardHandler - handleCardAction", () => {
         optionIndex: 2,
       }),
     );
-    await handler.handleCardAction(
+    const secondToggleResult = await handler.handleCardAction(
       buildCardAction({
         action: "question_toggle",
         requestId: "req-multi-select",
@@ -209,9 +210,22 @@ describe("QuestionCardHandler - handleCardAction", () => {
       }),
     );
 
+    expect(firstToggleResult).toEqual({
+      toast: {
+        type: "info",
+        content: "Selected: Edit",
+      },
+    });
+    expect(secondToggleResult).toEqual({
+      toast: {
+        type: "info",
+        content: "Selected: Bash, Edit",
+      },
+    });
+
     expect(client.question.reply).not.toHaveBeenCalled();
 
-    await handler.handleCardAction(
+    const submitResult = await handler.handleCardAction(
       buildCardAction({
         action: "question_submit",
         requestId: "req-multi-select",
@@ -219,10 +233,30 @@ describe("QuestionCardHandler - handleCardAction", () => {
       }),
     );
 
+    expect(submitResult).toEqual({
+      toast: {
+        type: "success",
+        content: "Answer submitted: Bash, Edit",
+      },
+    });
     expect(client.question.reply).toHaveBeenCalledWith({
       requestID: "req-multi-select",
       answers: [["Bash", "Edit"]],
     });
+    expect(renderer.updateCard).toHaveBeenCalledWith(
+      "msg-card-new",
+      expect.objectContaining({
+        header: expect.objectContaining({
+          template: "green",
+        }),
+        elements: expect.arrayContaining([
+          expect.objectContaining({
+            tag: "markdown",
+            content: expect.stringContaining("Which tools do you use?"),
+          }),
+        ]),
+      }),
+    );
   });
 
   it("ignores duplicate question submit callbacks while the first reply is still in flight", async () => {
@@ -298,6 +332,43 @@ describe("QuestionCardHandler - handleCardAction", () => {
 
     expect(result).toEqual({});
     expect(client.question.reply).not.toHaveBeenCalled();
+  });
+
+  it("supports nested callback payloads for question card actions", async () => {
+    const manager = new QuestionManager();
+    const renderer = createMockRenderer();
+    const client = createMockOpenCodeClient();
+
+    manager.startQuestions([QUESTION], "req-nested");
+    manager.setActiveMessageId("msg-nested-1");
+
+    const handler = createHandler(manager, renderer, client);
+
+    const result = await handler.handleCardAction({
+      event: {
+        context: {
+          open_message_id: "msg-nested-1",
+        },
+        action: {
+          value: {
+            action: "question_answer",
+            requestId: "req-nested",
+            optionIndex: 1,
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      toast: {
+        type: "success",
+        content: "Answer submitted: Vue",
+      },
+    });
+    expect(client.question.reply).toHaveBeenCalledWith({
+      requestID: "req-nested",
+      answers: [["Vue"]],
+    });
   });
 
   it("supports guided text replies for custom-answer questions", async () => {

--- a/tests/unit/runtime-event-handlers-queue.test.ts
+++ b/tests/unit/runtime-event-handlers-queue.test.ts
@@ -268,6 +268,69 @@ describe("runtime event handlers chat serialization", () => {
     await second;
   });
 
+  it("returns question card toast responses when control router has no reply", async () => {
+    const questionCardHandler = {
+      handleCardAction: vi.fn().mockResolvedValue({
+        toast: {
+          type: "info",
+          content: "Selected: Bash",
+        },
+      }),
+      canHandleTextReply: vi.fn().mockReturnValue(false),
+      handleTextReply: vi.fn(),
+    };
+
+    const handlers = createRuntimeEventHandlers({
+      promptIngressHandler: {
+        handlePromptInput: vi.fn(),
+        handleMessageEvent: vi.fn(),
+      } as never,
+      pipelineController: {
+        startTurn: vi.fn(),
+        recordFollowUpAppended: vi.fn().mockResolvedValue(undefined),
+      },
+      questionCardHandler: questionCardHandler as never,
+      permissionCardHandler: {
+        handleCardAction: vi.fn().mockResolvedValue({}),
+      },
+      controlRouter: {
+        parseCommand: vi.fn().mockReturnValue(null),
+        handleCommand: vi.fn(),
+        handleCardAction: vi.fn().mockResolvedValue({}),
+      },
+      fileHandler: {
+        isInboundFileMessage: vi.fn().mockReturnValue(false),
+        handleInboundFile: vi.fn(),
+        downloadFile: vi.fn(),
+        cleanup: vi.fn(),
+      },
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await expect(
+      handlers.handleCardAction({
+        open_message_id: "msg-question-card",
+        action: {
+          value: {
+            action: "question_toggle",
+            requestId: "req-1",
+            optionIndex: 0,
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      toast: {
+        type: "info",
+        content: "Selected: Bash",
+      },
+    });
+  });
+
   it("acknowledges appended follow-ups without starting a new turn", async () => {
     const promptResult = {
       kind: "appended",


### PR DESCRIPTION
## Summary

- Selection cards (`/new`, `/model`, `/session`, `/agent`, `/projects`) and question cards now update to a **resolved** (green header, showing selected value) or **cancelled** (grey header) state after user interaction, instead of remaining unchanged.
- Question card actions return **toast notifications** for immediate inline feedback (selection confirmation, answer submission).
- Three new card builders: `buildResolvedCard`, `buildCancelledCard`, `buildResolvedQuestionCard`.

## Changed files

- `src/feishu/cards.ts` — Added resolved/cancelled/question-resolved card builders
- `src/feishu/control-router.ts` — All card action handlers now call `updateActionCard` after processing; added `getCardActionOpenMessageId` helper
- `src/feishu/handlers/question.ts` — `handleCardAction` returns toast responses; `advanceQuestionFlow` updates card to resolved state after final submission

## Verification

- ESLint: 0 warnings, 0 errors
- TypeScript build: clean
- All 430 tests pass (64 test files)

Closes #40, Closes #41